### PR TITLE
#194 Basic solution to fix replay buffer settings set to 1

### DIFF
--- a/Examples/Assets/InfiniteWaves/Enemy/EnemyAdded.asset
+++ b/Examples/Assets/InfiniteWaves/Enemy/EnemyAdded.asset
@@ -13,5 +13,6 @@ MonoBehaviour:
   m_Name: EnemyAdded
   m_EditorClassIdentifier: 
   _developerDescription: Raised when an Enemy is added to the Enemies List.
+  UseLocalReplayBuffer: 1
   _replayBufferSize: 0
   _inspectorRaiseValue: {fileID: 0}

--- a/Examples/Assets/InfiniteWaves/Enemy/EnemyDataAddedBase.asset
+++ b/Examples/Assets/InfiniteWaves/Enemy/EnemyDataAddedBase.asset
@@ -14,5 +14,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _developerDescription: Raised when Enemy data is added to an Enemy Data Collection.
     This is a base Event that will be used as a base in an Instancer.
+  UseLocalReplayBuffer: 1
   _replayBufferSize: 2
   _inspectorRaiseValue: {fileID: 0}

--- a/Examples/Assets/InfiniteWaves/Enemy/EnemyDataRemovedBase.asset
+++ b/Examples/Assets/InfiniteWaves/Enemy/EnemyDataRemovedBase.asset
@@ -14,5 +14,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _developerDescription: Raised when Enemy data is removed from the Enemy data Collection
     its associated with. This is a base Event used for creating in memory copies.
+  UseLocalReplayBuffer: 1
   _replayBufferSize: 2
   _inspectorRaiseValue: {fileID: 0}

--- a/Examples/Assets/InfiniteWaves/Enemy/EnemyHealthChangedBase.asset
+++ b/Examples/Assets/InfiniteWaves/Enemy/EnemyHealthChangedBase.asset
@@ -14,5 +14,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _developerDescription: Raised when Enemy health is changed. This is a base Event
     used for creating in memory copies.
+  UseLocalReplayBuffer: 1
   _replayBufferSize: 1
   _inspectorRaiseValue: 0

--- a/Examples/Assets/InfiniteWaves/Enemy/EnemyPositionChangedBase.asset
+++ b/Examples/Assets/InfiniteWaves/Enemy/EnemyPositionChangedBase.asset
@@ -14,5 +14,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _developerDescription: Raised when Enemy position is changed. This is a base Event
     used for creating in memory copies.
+  UseLocalReplayBuffer: 1
   _replayBufferSize: 1
   _inspectorRaiseValue: {x: 0, y: 0, z: 0}

--- a/Examples/Assets/InfiniteWaves/Enemy/EnemyRemoved.asset
+++ b/Examples/Assets/InfiniteWaves/Enemy/EnemyRemoved.asset
@@ -13,5 +13,6 @@ MonoBehaviour:
   m_Name: EnemyRemoved
   m_EditorClassIdentifier: 
   _developerDescription: Raised when an Enemy is removed from Enemies list.
+  UseLocalReplayBuffer: 1
   _replayBufferSize: 0
   _inspectorRaiseValue: {fileID: 0}

--- a/Examples/Assets/InfiniteWaves/Enemy/EnemyStateChangedBase.asset
+++ b/Examples/Assets/InfiniteWaves/Enemy/EnemyStateChangedBase.asset
@@ -14,5 +14,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _developerDescription: Event raised when Enemy state is changed. This is a base
     Event used for creating in memory copies.
+  UseLocalReplayBuffer: 1
   _replayBufferSize: 0
   _inspectorRaiseValue: 

--- a/Examples/Assets/InfiniteWaves/EnemyWaveManager/SpawnedEnemyRemoved.asset
+++ b/Examples/Assets/InfiniteWaves/EnemyWaveManager/SpawnedEnemyRemoved.asset
@@ -14,5 +14,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _developerDescription: Raised when an Enemy is removed from the Spawned Enemies
     list.
+  UseLocalReplayBuffer: 1
   _replayBufferSize: 1
   _inspectorRaiseValue: {fileID: 0}

--- a/Examples/Assets/InfiniteWaves/EnemyWaveManager/WaveCountChanged.asset
+++ b/Examples/Assets/InfiniteWaves/EnemyWaveManager/WaveCountChanged.asset
@@ -13,5 +13,6 @@ MonoBehaviour:
   m_Name: WaveCountChanged
   m_EditorClassIdentifier: 
   _developerDescription: Raised when the wave count changes.
+  UseLocalReplayBuffer: 1
   _replayBufferSize: 1
   _inspectorRaiseValue: 0

--- a/Examples/Assets/InfiniteWaves/Projectile/ProjectileDidCollideBase.asset
+++ b/Examples/Assets/InfiniteWaves/Projectile/ProjectileDidCollideBase.asset
@@ -14,4 +14,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _developerDescription: Raised when a projectile do collide. This is a base Event
     used for creating in memory copies.
+  UseLocalReplayBuffer: 1
   _replayBufferSize: 1

--- a/Examples/Assets/InfiniteWaves/Projectile/ProjectileTriggerBase.asset
+++ b/Examples/Assets/InfiniteWaves/Projectile/ProjectileTriggerBase.asset
@@ -14,5 +14,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _developerDescription: Raised when a projectile enters a trigger. This is a base
     Event used for creating in memory copies.
+  UseLocalReplayBuffer: 1
   _replayBufferSize: 1
   _inspectorRaiseValue: {fileID: 0}

--- a/Examples/Assets/InfiniteWaves/UI/TryAgainButton/TryAgainButtonClicked.asset
+++ b/Examples/Assets/InfiniteWaves/UI/TryAgainButton/TryAgainButtonClicked.asset
@@ -14,4 +14,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _developerDescription: Raised when the player clicks the try again button in the
     game over screen.
+  UseLocalReplayBuffer: 1
   _replayBufferSize: 0

--- a/Examples/Assets/InfiniteWaves/UI/UIStateChanged.asset
+++ b/Examples/Assets/InfiniteWaves/UI/UIStateChanged.asset
@@ -13,5 +13,6 @@ MonoBehaviour:
   m_Name: UIStateChanged
   m_EditorClassIdentifier: 
   _developerDescription: Raised when UI state is changed.
+  UseLocalReplayBuffer: 1
   _replayBufferSize: 1
   _inspectorRaiseValue: 

--- a/Packages/Core/Runtime/Events/AtomEvent.cs
+++ b/Packages/Core/Runtime/Events/AtomEvent.cs
@@ -31,7 +31,7 @@ namespace UnityAtoms
         [SerializeField]
         [Range(0, 10)]
         [Tooltip("The number of old values (between 0-10) being replayed when someone subscribes to this Event.")]
-        private int _replayBufferSize = 1;
+        private int _replayBufferSize = 0;
 
         private Queue<T> _replayBuffer = new Queue<T>();
 

--- a/Packages/Core/Runtime/Events/AtomEvent.cs
+++ b/Packages/Core/Runtime/Events/AtomEvent.cs
@@ -14,6 +14,9 @@ namespace UnityAtoms
     {
         public T InspectorRaiseValue { get => _inspectorRaiseValue; }
 
+        [SerializeField]
+        private bool UseLocalReplayBuffer = false;
+
         /// <summary>
         /// Retrieve Replay Buffer as a List. This call will allocate memory so use sparsely.
         /// </summary>
@@ -37,7 +40,10 @@ namespace UnityAtoms
 
         private void OnEnable()
         {
-            _replayBufferSize = AtomPreferences.ReplayBufferSize;
+            if (!UseLocalReplayBuffer)
+            {
+                _replayBufferSize = AtomPreferences.ReplayBufferSize;
+            }
         }
 
         private void OnDisable()

--- a/Packages/Core/Runtime/Events/AtomEvent.cs
+++ b/Packages/Core/Runtime/Events/AtomEvent.cs
@@ -31,9 +31,14 @@ namespace UnityAtoms
         [SerializeField]
         [Range(0, 10)]
         [Tooltip("The number of old values (between 0-10) being replayed when someone subscribes to this Event.")]
-        private int _replayBufferSize = 0;
+        private int _replayBufferSize;
 
         private Queue<T> _replayBuffer = new Queue<T>();
+
+        private void OnEnable()
+        {
+            _replayBufferSize = AtomPreferences.ReplayBufferSize;
+        }
 
         private void OnDisable()
         {

--- a/Packages/Core/Runtime/Listeners/AtomBaseListener.cs
+++ b/Packages/Core/Runtime/Listeners/AtomBaseListener.cs
@@ -7,8 +7,7 @@ namespace UnityAtoms
     /// <summary>
     /// None generic base class for all Listeners.
     /// </summary>
-    /// Default Execution order of 100 to make sure that listeners OnEnable runs before variables OnEnable() method.
-    [DefaultExecutionOrder(100)]
+    [DefaultExecutionOrder(Runtime.ExecutionOrder.LISTENER_BASE)]
     public abstract class AtomBaseListener : MonoBehaviour
     {
         /// <summary>

--- a/Packages/Core/Runtime/Listeners/AtomBaseListener.cs
+++ b/Packages/Core/Runtime/Listeners/AtomBaseListener.cs
@@ -7,6 +7,8 @@ namespace UnityAtoms
     /// <summary>
     /// None generic base class for all Listeners.
     /// </summary>
+    /// Default Execution order of 100 to make sure that listeners OnEnable runs before variables OnEnable() method.
+    [DefaultExecutionOrder(100)]
     public abstract class AtomBaseListener : MonoBehaviour
     {
         /// <summary>

--- a/Packages/Core/Runtime/Preferences/AtomsPreferences.cs
+++ b/Packages/Core/Runtime/Preferences/AtomsPreferences.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_EDITOR
+#if UNITY_EDITOR
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor;
@@ -40,9 +40,31 @@ namespace UnityAtoms
             }
         }
 
+        public class IntPreference : Preference<int>
+        {
+            public override int Get()
+            {
+                if (!EditorPrefs.HasKey(Key))
+                {
+                    EditorPrefs.SetInt(Key, DefaultValue);
+                }
+
+                return EditorPrefs.GetInt(Key);
+            }
+
+            public override void Set(int value)
+            {
+                EditorPrefs.SetInt(Key, value);
+            }
+        }
+
         public static bool IsDebugModeEnabled { get => DEBUG_MODE_PREF.Get(); }
 
         private static BoolPreference DEBUG_MODE_PREF = new BoolPreference() { DefaultValue = false, Key = "UnityAtoms.DebugMode" };
+
+        public static int ReplayBufferSize { get => DEFAULT_BUFFER_SIZE_PREF.Get(); }
+
+        private static IntPreference DEFAULT_BUFFER_SIZE_PREF = new IntPreference() { DefaultValue = 0, Key = "UnityAtoms.ReplayBufferSize" };
 
 #if UNITY_2019_1_OR_NEWER
         [SettingsProvider]
@@ -88,6 +110,19 @@ namespace UnityAtoms
                     };
                     enableDebug.RegisterValueChangedCallback((changeEvt) => DEBUG_MODE_PREF.Set(changeEvt.newValue));
                     wrapper.Add(enableDebug);
+
+                    var replayBufferSize = new TextField()
+                    {
+                        label = "Default replay buffer size",
+                        value = DEFAULT_BUFFER_SIZE_PREF.Get().ToString(),
+                        tooltip = "Set the default replay buffer size for each new created Event.",
+                        style = {
+                            marginRight = 1250
+                        }
+                    };
+
+                    replayBufferSize.RegisterValueChangedCallback((changeEvt) => DEFAULT_BUFFER_SIZE_PREF.Set(int.Parse(changeEvt.newValue)));
+                    wrapper.Add(replayBufferSize);
 
                     rootElement.Add(wrapper);
                 },

--- a/Packages/Core/Runtime/Preferences/AtomsPreferences.cs
+++ b/Packages/Core/Runtime/Preferences/AtomsPreferences.cs
@@ -111,17 +111,16 @@ namespace UnityAtoms
                     enableDebug.RegisterValueChangedCallback((changeEvt) => DEBUG_MODE_PREF.Set(changeEvt.newValue));
                     wrapper.Add(enableDebug);
 
-                    var replayBufferSize = new TextField()
+                    var replayBufferSize = new SliderInt()
                     {
-                        label = "Default replay buffer size",
-                        value = DEFAULT_BUFFER_SIZE_PREF.Get().ToString(),
+                        label = "Replay buffer size (1-10)",
+                        highValue = 10,
+                        lowValue = 0,
+                        pageSize = 1,
+                        value = DEFAULT_BUFFER_SIZE_PREF.Get(),
                         tooltip = "Set the default replay buffer size for each new created Event.",
-                        style = {
-                            marginRight = 1250
-                        }
                     };
-
-                    replayBufferSize.RegisterValueChangedCallback((changeEvt) => DEFAULT_BUFFER_SIZE_PREF.Set(int.Parse(changeEvt.newValue)));
+                    replayBufferSize.RegisterValueChangedCallback((changeEvt) => DEFAULT_BUFFER_SIZE_PREF.Set(changeEvt.newValue));
                     wrapper.Add(replayBufferSize);
 
                     rootElement.Add(wrapper);

--- a/Packages/Core/Runtime/Utils/Runtime.cs
+++ b/Packages/Core/Runtime/Utils/Runtime.cs
@@ -23,10 +23,10 @@ namespace UnityAtoms
         /// </summary>
         public static class ExecutionOrder
         {
-            public const int LISTENER_BASE = -400;
-            public const int VARIABLE_BASE = -300;
-            public const int VARIABLE_RESETTER = -200;
-            public const int VARIABLE_INSTANCER = -100;
+            public const int VARIABLE_BASE = -400;
+            public const int VARIABLE_RESETTER = -300;
+            public const int VARIABLE_INSTANCER = -200;
+            public const int LISTENER_BASE = -100;
         }
 
         /// <summary>

--- a/Packages/Core/Runtime/Utils/Runtime.cs
+++ b/Packages/Core/Runtime/Utils/Runtime.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 
 namespace UnityAtoms
 {
@@ -23,6 +23,8 @@ namespace UnityAtoms
         /// </summary>
         public static class ExecutionOrder
         {
+            public const int LISTENER_BASE = -400;
+            public const int VARIABLE_BASE = -300;
             public const int VARIABLE_RESETTER = -200;
             public const int VARIABLE_INSTANCER = -100;
         }

--- a/Packages/Core/Runtime/Variables/AtomBaseVariable.cs
+++ b/Packages/Core/Runtime/Variables/AtomBaseVariable.cs
@@ -7,6 +7,8 @@ namespace UnityAtoms
     /// None generic base class for Variables. Inherits from `BaseAtom`.
     /// </summary>
     [EditorIcon("atom-icon-teal")]
+    /// Default Execution order of 200 to make sure that variables OnEnable runs after listeners OnEnable() method.
+    [DefaultExecutionOrder(200)]
     public abstract class AtomBaseVariable : BaseAtom
     {
         public String Id { get => _id; set => _id = value; }

--- a/Packages/Core/Runtime/Variables/AtomBaseVariable.cs
+++ b/Packages/Core/Runtime/Variables/AtomBaseVariable.cs
@@ -7,8 +7,7 @@ namespace UnityAtoms
     /// None generic base class for Variables. Inherits from `BaseAtom`.
     /// </summary>
     [EditorIcon("atom-icon-teal")]
-    /// Default Execution order of 200 to make sure that variables OnEnable runs after listeners OnEnable() method.
-    [DefaultExecutionOrder(200)]
+    [DefaultExecutionOrder(Runtime.ExecutionOrder.VARIABLE_BASE)]
     public abstract class AtomBaseVariable : BaseAtom
     {
         public String Id { get => _id; set => _id = value; }


### PR DESCRIPTION
Addresses #194 

Sets a default execution order attribute for all listeners and variables so that Listeners OnEnable() runs before Variables OnEnable().

This should allow new created event replay buffer settings be initialized to 0.