### PR TITLE
Create button ease of use

### DIFF
--- a/Packages/Core/Editor/Drawers/AtomDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomDrawer.cs
@@ -19,6 +19,8 @@ namespace UnityAtoms.Editor
             public string WarningText = "";
         }
 
+        private const string NAMING_FIELD_CONTROL_NAME = "Naming Field";
+
         private Dictionary<string, DrawerData> _perPropertyViewData = new Dictionary<string, DrawerData>();
 
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
@@ -81,11 +83,10 @@ namespace UnityAtoms.Editor
             var indent = EditorGUI.indentLevel;
             EditorGUI.indentLevel = 0;
 
-            if (isCreatingSO)
-            {
-                drawerData.NameOfNewAtom = EditorGUI.TextField(position, drawerData.NameOfNewAtom);
-            }
-            else
+            GUI.SetNextControlName(NAMING_FIELD_CONTROL_NAME);
+            drawerData.NameOfNewAtom = EditorGUI.TextField(isCreatingSO ? position : Rect.zero, drawerData.NameOfNewAtom);
+
+            if (!isCreatingSO)
             {
                 EditorGUI.BeginChangeCheck();
                 var obj = EditorGUI.ObjectField(position, property.objectReferenceValue, typeof(T), false);
@@ -129,6 +130,7 @@ namespace UnityAtoms.Editor
                         else
                         {
                             drawerData.WarningText = "Name of new Atom must be specified!";
+                            EditorGUI.FocusTextInControl(NAMING_FIELD_CONTROL_NAME);
                         }
                     }
                     if (GUI.Button(secondButtonRect, "✗"))
@@ -148,6 +150,8 @@ namespace UnityAtoms.Editor
                     {
                         drawerData.NameOfNewAtom = "";
                         drawerData.UserClickedToCreateAtom = true;
+
+                        EditorGUI.FocusTextInControl(NAMING_FIELD_CONTROL_NAME);
                     }
                 }
             }

--- a/Packages/Core/Editor/Drawers/AtomDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomDrawer.cs
@@ -104,7 +104,8 @@ namespace UnityAtoms.Editor
                     var buttonWidth = 24;
                     Rect secondButtonRect;
                     Rect firstButtonRect = IMGUIUtils.SnipRectH(restRect, restRect.width - buttonWidth, out secondButtonRect, gutter);
-                    if (GUI.Button(firstButtonRect, "✓"))
+                    if (GUI.Button(firstButtonRect, "✓")
+                        || Event.current.keyCode == KeyCode.Return)
                     {
                         if (drawerData.NameOfNewAtom.Length > 0)
                         {
@@ -133,7 +134,8 @@ namespace UnityAtoms.Editor
                             EditorGUI.FocusTextInControl(NAMING_FIELD_CONTROL_NAME);
                         }
                     }
-                    if (GUI.Button(secondButtonRect, "✗"))
+                    if (GUI.Button(secondButtonRect, "✗")
+                        || Event.current.keyCode == KeyCode.Escape)
                     {
                         drawerData.UserClickedToCreateAtom = false;
                         drawerData.WarningText = "";

--- a/Packages/Core/Editor/Drawers/AtomDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomDrawer.cs
@@ -77,7 +77,7 @@ namespace UnityAtoms.Editor
 
             var defaultGUIColor = GUI.color;
             GUI.color = isCreatingSO ? Color.yellow : defaultGUIColor;
-            position = EditorGUI.PrefixLabel(position, GUIUtility.GetControlID(FocusType.Passive), isCreatingSO ? new GUIContent("Name of New Atom") : label);
+            position = EditorGUI.PrefixLabel(position, GUIUtility.GetControlID(FocusType.Passive), isCreatingSO && label != GUIContent.none ? new GUIContent("Name of New Atom") : label);
             GUI.color = defaultGUIColor;
 
             var indent = EditorGUI.indentLevel;

--- a/Packages/Core/Editor/Drawers/AtomDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomDrawer.cs
@@ -94,7 +94,6 @@ namespace UnityAtoms.Editor
                 {
                     property.objectReferenceValue = obj;
                 }
-
             }
 
             if (property.objectReferenceValue == null)

--- a/Packages/Core/Editor/Drawers/AtomDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomDrawer.cs
@@ -104,7 +104,8 @@ namespace UnityAtoms.Editor
                     Rect secondButtonRect;
                     Rect firstButtonRect = IMGUIUtils.SnipRectH(restRect, restRect.width - buttonWidth, out secondButtonRect, gutter);
                     if (GUI.Button(firstButtonRect, "✓")
-                        || Event.current.keyCode == KeyCode.Return)
+                        || (Event.current.keyCode == KeyCode.Return
+                            && GUI.GetNameOfFocusedControl() == NAMING_FIELD_CONTROL_NAME))
                     {
                         if (drawerData.NameOfNewAtom.Length > 0)
                         {
@@ -134,7 +135,8 @@ namespace UnityAtoms.Editor
                         }
                     }
                     if (GUI.Button(secondButtonRect, "✗")
-                        || Event.current.keyCode == KeyCode.Escape)
+                        || (Event.current.keyCode == KeyCode.Escape
+                            && GUI.GetNameOfFocusedControl() == NAMING_FIELD_CONTROL_NAME))
                     {
                         drawerData.UserClickedToCreateAtom = false;
                         drawerData.WarningText = "";


### PR DESCRIPTION
Will make the create button a bit easier to use.

- When the Create button is clicked, the naming field gets auto-focus.
- If the Create button is used in a reference field, the PrefixLabel will no longer clog the inspector.
- The confirm create and deny create buttons also get triggered when return (enter) or escape is pressed respectively.