### PR TITLE
fixing #240 - Value of a VariableInstancer in EditMode leads to NullRef

### DIFF
--- a/Packages/Core/Runtime/References/AtomReference.cs
+++ b/Packages/Core/Runtime/References/AtomReference.cs
@@ -35,7 +35,7 @@ namespace UnityAtoms
                 {
                     case (AtomReferenceUsage.CONSTANT): return _constant == null ? default(T) : _constant.Value;
                     case (AtomReferenceUsage.VARIABLE): return _variable == null ? default(T) : _variable.Value;
-                    case (AtomReferenceUsage.VARIABLE_INSTANCER): return _variableInstancer == null ? default(T) : _variableInstancer.Value;
+                    case (AtomReferenceUsage.VARIABLE_INSTANCER): return _variableInstancer == null || _variableInstancer.Variable == null ? default(T) : _variableInstancer.Value;
                     case (AtomReferenceUsage.VALUE):
                     default:
                         return _value;
@@ -76,7 +76,7 @@ namespace UnityAtoms
                 {
                     case (AtomReferenceUsage.CONSTANT): return _constant == null;
                     case (AtomReferenceUsage.VARIABLE): return _variable == null;
-                    case (AtomReferenceUsage.VARIABLE_INSTANCER): return _variableInstancer == null;
+                    case (AtomReferenceUsage.VARIABLE_INSTANCER): return _variableInstancer == null || _variableInstancer.Variable == null;
                 }
                 return false;
             }

--- a/Packages/Core/Runtime/VariableInstancers/AtomBaseVariableInstancer.cs
+++ b/Packages/Core/Runtime/VariableInstancers/AtomBaseVariableInstancer.cs
@@ -47,7 +47,7 @@ namespace UnityAtoms
         /// </summary>
         protected virtual void ImplSpecificSetup() { }
 
-        private void OnEnable()
+        private void Start()
         {
             if (Base == null)
             {


### PR DESCRIPTION
See #240 
should fix a nullref exception when checking the Value of a VariableInstancer on a Reference might lead to null reference exceptions