### PR TITLE
#243 Add scope (or lifetime) management

### DIFF
--- a/Packages/Core/Editor/Editors/Events/AtomEventEditor.cs
+++ b/Packages/Core/Editor/Editors/Events/AtomEventEditor.cs
@@ -1,6 +1,11 @@
 #if UNITY_2019_1_OR_NEWER
 using UnityEngine;
 using UnityEngine.UIElements;
+using UnityEditor;
+#if USE_ADDRESSABLES
+using UnityEditor.AddressableAssets;
+using UnityEditor.AddressableAssets.Settings;
+#endif
 
 namespace UnityAtoms.Editor
 {
@@ -15,6 +20,11 @@ namespace UnityAtoms.Editor
         public override VisualElement CreateInspectorGUI()
         {
             var root = new VisualElement();
+
+            #if USE_ADDRESSABLES
+            IMGUIContainer addressablesWarning = new IMGUIContainer(AddressableWarningHandler);
+            root.Add(addressablesWarning);
+            #endif
 
             IMGUIContainer defaultInspector = new IMGUIContainer(() => DrawDefaultInspector());
             root.Add(defaultInspector);
@@ -37,6 +47,24 @@ namespace UnityAtoms.Editor
 #endif
 
             return root;
+        }
+
+        private void AddressableWarningHandler()
+        {
+            AddressableAssetSettings settings = AddressableAssetSettingsDefaultObject.Settings;
+            string assetPath = AssetDatabase.GetAssetPath(serializedObject.targetObject);
+            string guid = AssetDatabase.AssetPathToGUID(assetPath);
+            AddressableAssetEntry entry = settings.FindAssetEntry(guid);
+
+            if (entry != null)
+            {
+                EditorGUILayout.HelpBox("This asset is marked as addressable, his lifetime will not be managed by Unity Atoms.\nSee more in documentation", MessageType.Warning);
+            }
+            else
+            {
+                EditorGUILayout.HelpBox("Addressables is installed, careful, Unity Atoms might be unable to manage the asset.\nSee more in documentation", MessageType.Info);
+            }
+            EditorGUILayout.Space();
         }
     }
 }

--- a/Packages/Core/Editor/UnityAtoms.UnityAtomsCore.Editor.asmdef
+++ b/Packages/Core/Editor/UnityAtoms.UnityAtomsCore.Editor.asmdef
@@ -1,9 +1,9 @@
 {
     "name": "UnityAtoms.UnityAtomsCore.Editor",
     "references": [
-        "UnityAtoms.UnityAtomsCore.Runtime"
+        "UnityAtoms.UnityAtomsCore.Runtime",
+        "Unity.Addressables.Editor"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
@@ -13,5 +13,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": []
+    "versionDefines": [
+        {
+            "name": "com.unity.addressables",
+            "expression": "1.0",
+            "define": "USE_ADDRESSABLES"
+        }
+    ],
+    "noEngineReferences": false
 }

--- a/Packages/Core/Runtime/Base/BaseAtom.cs
+++ b/Packages/Core/Runtime/Base/BaseAtom.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace UnityAtoms
 {
@@ -14,5 +15,34 @@ namespace UnityAtoms
         [SerializeField]
         [TextArea(3, 6)]
         private string _developerDescription;
+
+        /// <summary>
+        /// Manage how the scriptable object is loaded/unloaded or if it reset its value between scene
+        /// </summary>
+        /// <param name="scope"></param>
+        internal void ManageLifetime(Scope scope)
+        {
+            switch (scope)
+            {
+                case Scope.Global:
+                    hideFlags = HideFlags.DontUnloadUnusedAsset;
+                    break;
+                case Scope.Scene:
+                    SceneManager.activeSceneChanged += OnActiveSceneChanged;
+                    break;
+                case Scope.Unmanaged:
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Callback called when main scene is changing
+        /// </summary>
+        /// <remarks>
+        /// Use this callback to reset the SO value when the scope is set to <c>Scope.Scene</c>
+        /// </remarks>
+        /// <param name="scene1">Current scene</param>
+        /// <param name="scene2">Next scene</param>
+        protected virtual void OnActiveSceneChanged(Scene current, Scene next) { }
     }
 }

--- a/Packages/Core/Runtime/Types/Scope.cs
+++ b/Packages/Core/Runtime/Types/Scope.cs
@@ -1,0 +1,9 @@
+﻿namespace UnityAtoms
+{
+    internal enum Scope
+    {
+        Global,
+        Scene,
+        Unmanaged
+    }
+}

--- a/Packages/Core/Runtime/Types/Scope.cs.meta
+++ b/Packages/Core/Runtime/Types/Scope.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 572d3cc6449a4185b5ac0a1c1d174ce9
+timeCreated: 1611689679

--- a/Packages/FSM/Runtime/FiniteStateMachine/FiniteStateMachine.cs
+++ b/Packages/FSM/Runtime/FiniteStateMachine/FiniteStateMachine.cs
@@ -15,7 +15,7 @@ namespace UnityAtoms.FSM
     public class FiniteStateMachine : StringVariable
     {
         /// <summary>
-        /// Get or set current value of this FSM. If a sub FSM is having the current state, then its state will be returned. Using the setter is the same thing as calling `Dispatch`. 
+        /// Get or set current value of this FSM. If a sub FSM is having the current state, then its state will be returned. Using the setter is the same thing as calling `Dispatch`.
         /// </summary>
         /// <value>The command to issue.</value>
         public override string Value
@@ -64,8 +64,10 @@ namespace UnityAtoms.FSM
         /// </summary>
         private string _currentFlatValue;
 
-        private void OnEnable()
+        protected override void OnEnable()
         {
+            base.OnEnable();
+
             if (CompleteCurrentTransition != null && CompleteCurrentTransition.ReplayBufferSize > 0)
             {
                 Debug.LogWarning("The Complete Current Transition event had a replay buffer size great than 0, which would cause unwanted behaviour. Setting it to 0 in order to avoid unexpected behaviour.");
@@ -109,8 +111,10 @@ namespace UnityAtoms.FSM
             }
         }
 
-        private void OnDisable()
+        protected override void OnDisable()
         {
+            base.OnDisable();
+
             if (FiniteStateMachineMonoHook.GetInstance() != null)
             {
                 FiniteStateMachineMonoHook.GetInstance().OnUpdate -= OnUpdate;


### PR DESCRIPTION
Hi :wave:

This is WIP, but I wanted to share my work and maybe open the discussion

### Runtime changes

- Add a `Scope` Enum
- Add a `ManageLifetime` method in `BaseAtom` as it could be used by Variables, Lists and Collections
- In `AtomVariable`, when scriptable object is enabled its behavior will be defined
    * `Scope.Global`: Will set the [DontUnloadUnusedAsset](https://docs.unity3d.com/ScriptReference/HideFlags.DontUnloadUnusedAsset.html) hide flag, the SO will not be unload automatically during runtime
    * `Scope.Scene`: Will add a listener to [SceneManager.activeSceneChanged](https://docs.unity3d.com/ScriptReference/SceneManagement.SceneManager-activeSceneChanged.html) that will reset the SO value to `InitialValue`
- FSM script will call base `OnEnable`
  
### Editor changes

- Define #USE_ADDRESSABLES if addressables package is installed
- Show an HelpBox in Variable and Event inspector is addressables is installed or if the asset is marked as addressable
- In variable editor, force the scope value to `Unmanaged` is the asset is marked as addressable
- In variable editor, disable scope edition in runtime

### What is missing

- Documentation about lifetime, why it's important and how to work with addressables
- List and Collection lifetime management (and their editors). I might want to wait for generic editors for this

Other atoms type such as constants or actions should be ok with this issue