### PR TITLE
Fixes #265 Atom event code cleanup

### DIFF
--- a/Packages/Core/Editor/Extensions/StringExtensions.cs
+++ b/Packages/Core/Editor/Extensions/StringExtensions.cs
@@ -14,11 +14,7 @@ namespace UnityAtoms
         /// <param name="str">The string to parse.</param>
         /// <param name="def">The default value if not able to parse the provided string.</param>
         /// <returns>Returns the string parsed to an int. If not able to parse the string, it returns the default value provided to the method.</returns>
-        public static int ToInt(this string str, int def)
-        {
-            int num;
-            return int.TryParse(str, out num) ? num : def;
-        }
+        public static int ToInt(this string str, int def) => int.TryParse(str, out int num) ? num : def;
 
         /// <summary>
         /// Repeats the string X amount of times.

--- a/Packages/Core/Runtime/AtomListWrapper/AtomListWrapper.cs
+++ b/Packages/Core/Runtime/AtomListWrapper/AtomListWrapper.cs
@@ -9,9 +9,8 @@ namespace UnityAtoms
     /// <typeparam name="T">Type used in list.</typeparam>
     public abstract class AtomListWrapper<T>
     {
-        public List<T> List { get => _list; }
+        public List<T> List => _list;
 
-        [SerializeField]
-        private List<T> _list = default;
+        [SerializeField] private List<T> _list = default;
     }
 }

--- a/Packages/Core/Runtime/Events/AtomEvent.cs
+++ b/Packages/Core/Runtime/Events/AtomEvent.cs
@@ -41,7 +41,7 @@ namespace UnityAtoms
         private int _replayBufferSize = 1;
 
         /// <summary>
-        /// Queue used as a replay buffer.
+        /// Stores the replay buffer.
         /// </summary>
         private readonly Queue<T> _replayBuffer = new Queue<T>();
 
@@ -140,37 +140,23 @@ namespace UnityAtoms
         protected void AddToReplayBuffer(T item)
         {
             if (_replayBufferSize <= 0) return;
-            TrimReplayBuffer();
+
+            while (_replayBuffer.Count >= _replayBufferSize)
+                _replayBuffer.Dequeue();
+
             _replayBuffer.Enqueue(item);
         }
 
         /// <summary>
-        /// Trim the replay buffer by removing excess items.
-        /// </summary>
-        private void TrimReplayBuffer()
-        {
-            while (_replayBuffer.Count >= _replayBufferSize)
-                _replayBuffer.Dequeue();
-        }
-
-        /// <summary>
-        /// Replay buffer into a subscriber.
+        /// Invokes the <paramref name="action"/> on every element in the replayBuffer.
         /// </summary>
         /// <param name="action">The action to call on each item in the replay buffer.</param>
         private void ReplayBufferToSubscriber(Action<T> action)
         {
             if (_replayBufferSize <= 0 || _replayBuffer.Count <= 0) return;
 
-            var enumerator = _replayBuffer.GetEnumerator();
-            try
-            {
-                while (enumerator.MoveNext())
-                    action(enumerator.Current);
-            }
-            finally
-            {
-                enumerator.Dispose();
-            }
+            foreach (T item in _replayBuffer)
+                action(item);
         }
     }
 }

--- a/Packages/Core/Runtime/Events/AtomEventBase.cs
+++ b/Packages/Core/Runtime/Events/AtomEventBase.cs
@@ -1,11 +1,10 @@
 using System;
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace UnityAtoms
 {
     /// <summary>
-    /// None generic base class for Events. Inherits from `BaseAtom` and `ISerializationCallbackReceiver`.
+    /// Non-generic base class for Events.
     /// </summary>
     [EditorIcon("atom-icon-cherry")]
     public abstract class AtomEventBase : BaseAtom, ISerializationCallbackReceiver
@@ -15,7 +14,9 @@ namespace UnityAtoms
         /// </summary>
         public event Action OnEventNoValue;
 
-
+        /// <summary>
+        /// Raise the Event.
+        /// </summary>
         public virtual void Raise()
         {
 #if !UNITY_ATOMS_GENERATE_DOCS && UNITY_EDITOR
@@ -68,19 +69,14 @@ namespace UnityAtoms
             OnEventNoValue -= listener.OnEventRaised;
         }
 
+        /// <inheritdoc />
         public void OnBeforeSerialize() { }
 
+        /// <inheritdoc />
         public virtual void OnAfterDeserialize()
         {
             // Clear all delegates when exiting play mode
-            if (OnEventNoValue != null)
-            {
-                foreach (var d in OnEventNoValue.GetInvocationList())
-                {
-                    OnEventNoValue -= (Action)d;
-                }
-            }
+            OnEventNoValue = null;
         }
-
     }
 }

--- a/Packages/Core/Runtime/Extensions/IListExtensions.cs
+++ b/Packages/Core/Runtime/Extensions/IListExtensions.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
-using Object = UnityEngine.Object;
 
 namespace UnityAtoms
 {
@@ -10,15 +9,17 @@ namespace UnityAtoms
         public static T First<T>(this IList<T> list, Func<T, bool> func)
         {
             for (int i = 0; list != null && i < list.Count; ++i)
+            {
                 if (func(list[i])) return list[i];
+            }
 
             return default(T);
         }
 
         public static bool Exists<T>(this IList<T> list, Func<T, bool> func)
         {
-            var first = list.First(func);
-            return first is { };
+            var first = list.First<T>(func);
+            return first != null ? true : false;
         }
 
         public static GameObject GetOrInstantiate(this IList<GameObject> list, UnityEngine.Object prefab, Vector3 position, Quaternion quaternion, Func<GameObject, bool> condition)
@@ -32,7 +33,7 @@ namespace UnityAtoms
                 return component;
             }
 
-            var newGameObject = Object.Instantiate(prefab, position, quaternion) as GameObject;
+            var newGameObject = GameObject.Instantiate(prefab, position, quaternion) as GameObject;
             list.Add(newGameObject);
             return newGameObject;
         }

--- a/Packages/Core/Runtime/Extensions/IListExtensions.cs
+++ b/Packages/Core/Runtime/Extensions/IListExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace UnityAtoms
 {
@@ -9,17 +10,15 @@ namespace UnityAtoms
         public static T First<T>(this IList<T> list, Func<T, bool> func)
         {
             for (int i = 0; list != null && i < list.Count; ++i)
-            {
                 if (func(list[i])) return list[i];
-            }
 
             return default(T);
         }
 
         public static bool Exists<T>(this IList<T> list, Func<T, bool> func)
         {
-            var first = list.First<T>(func);
-            return first != null ? true : false;
+            var first = list.First(func);
+            return first is { };
         }
 
         public static GameObject GetOrInstantiate(this IList<GameObject> list, UnityEngine.Object prefab, Vector3 position, Quaternion quaternion, Func<GameObject, bool> condition)
@@ -33,7 +32,7 @@ namespace UnityAtoms
                 return component;
             }
 
-            var newGameObject = GameObject.Instantiate(prefab, position, quaternion) as GameObject;
+            var newGameObject = Object.Instantiate(prefab, position, quaternion) as GameObject;
             list.Add(newGameObject);
             return newGameObject;
         }

--- a/Packages/Core/Runtime/Functions/AtomFunction.cs
+++ b/Packages/Core/Runtime/Functions/AtomFunction.cs
@@ -13,27 +13,26 @@ namespace UnityAtoms
         /// <summary>
         /// The actual function.
         /// </summary>
-        [HideInInspector]
         public Func<R> Func;
 
         /// <summary>
         /// Call the Function.
         /// </summary>
+        /// <exception cref="InvalidOperationException">If <see cref="Func"/> is not set.</exception>
         /// <returns>Whatever the function decides to return of type `R`.</returns>
         public virtual R Call()
         {
-            if (Func != null)
-            {
-                return Func();
-            }
+            if (Func == null)
+                throw new InvalidOperationException("Either set Func or override the Call method.");
 
-            throw new Exception("Either set Func or override the Call method.");
+            return Func();
         }
 
         /// <summary>
         /// Set the Function providing a `Func&lt;R&gt;`.
         /// </summary>
         /// <param name="func">The `Func&lt;R&gt;` to set.</param>
+        /// <exception cref="InvalidOperationException">If <see cref="Func"/> is not set.</exception>
         /// <returns>An `AtomFunction&lt;R&gt;`.</returns>
         public AtomFunction<R> SetFunc(Func<R> func)
         {
@@ -53,22 +52,20 @@ namespace UnityAtoms
         /// <summary>
         /// The actual function.
         /// </summary>
-        [HideInInspector]
         public Func<T1, R> Func;
 
         /// <summary>
         /// Call the Function.
         /// </summary>
         /// <param name="t1">The first parameter.</param>
+        /// <exception cref="InvalidOperationException">If <see cref="Func"/> is not set.</exception>
         /// <returns>Whatever the function decides to return of type `R`.</returns>
         public virtual R Call(T1 t1)
         {
-            if (Func != null)
-            {
-                return Func(t1);
-            }
+            if (Func == null)
+                throw new InvalidOperationException("Either set Func or override the Call method.");
 
-            throw new Exception("Either set Func or override the Call method.");
+            return Func(t1);
         }
 
         /// <summary>
@@ -95,7 +92,6 @@ namespace UnityAtoms
         /// <summary>
         /// The actual function.
         /// </summary>
-        [HideInInspector]
         public Func<T1, T2, R> Func;
 
         /// <summary>
@@ -103,15 +99,14 @@ namespace UnityAtoms
         /// </summary>
         /// <param name="t1">The first parameter.</param>
         /// <param name="t2">The second parameter.</param>
+        /// <exception cref="InvalidOperationException">If <see cref="Func"/> is not set.</exception>
         /// <returns>Whatever the function decides to return of type `R`.</returns>
         public virtual R Call(T1 t1, T2 t2)
         {
-            if (Func != null)
-            {
-                return Func(t1, t2);
-            }
+            if (Func == null)
+                throw new InvalidOperationException("Either set Func or override the Call method.");
 
-            throw new Exception("Either set Func or override the Call method.");
+            return Func(t1, t2);
         }
 
         /// <summary>
@@ -139,7 +134,6 @@ namespace UnityAtoms
         /// <summary>
         /// The actual function.
         /// </summary>
-        [HideInInspector]
         public Func<T1, T2, T3, R> Func;
 
         /// <summary>
@@ -148,15 +142,14 @@ namespace UnityAtoms
         /// <param name="t1">The first parameter.</param>
         /// <param name="t2">The second parameter.</param>
         /// <param name="t3">The third parameter.</param>
+        /// <exception cref="InvalidOperationException">If <see cref="Func"/> is not set.</exception>
         /// <returns>Whatever the function decides to return of type `R`.</returns>
         public virtual R Call(T1 t1, T2 t2, T3 t3)
         {
-            if (Func != null)
-            {
-                return Func(t1, t2, t3);
-            }
+            if (Func == null)
+                throw new InvalidOperationException("Either set Func or override the Call method.");
 
-            throw new Exception("Either set Func or override the Call method.");
+            return Func(t1, t2, t3);
         }
 
         /// <summary>
@@ -185,7 +178,6 @@ namespace UnityAtoms
         /// <summary>
         /// The actual function.
         /// </summary>
-        [HideInInspector]
         public Func<T1, T2, T3, T4, R> Func;
 
         /// <summary>
@@ -195,15 +187,14 @@ namespace UnityAtoms
         /// <param name="t2">The second parameter.</param>
         /// <param name="t3">The third parameter.</param>
         /// <param name="t4">The fourth parameter.</param>
+        /// <exception cref="InvalidOperationException">If <see cref="Func"/> is not set.</exception>
         /// <returns>Whatever the function decides to return of type `R`.</returns>
         public virtual R Call(T1 t1, T2 t2, T3 t3, T4 t4)
         {
-            if (Func != null)
-            {
-                return Func(t1, t2, t3, t4);
-            }
+            if (Func == null)
+                throw new InvalidOperationException("Either set Func or override the Call method.");
 
-            throw new Exception("Either set Func or override the Call method.");
+            return Func(t1, t2, t3, t4);
         }
 
         /// <summary>
@@ -233,7 +224,6 @@ namespace UnityAtoms
         /// <summary>
         /// The actual function.
         /// </summary>
-        [HideInInspector]
         public Func<T1, T2, T3, T4, T5, R> Func;
 
         /// <summary>
@@ -244,15 +234,14 @@ namespace UnityAtoms
         /// <param name="t3">The third parameter.</param>
         /// <param name="t4">The fourth parameter.</param>
         /// <param name="t5">The fifth parameter.</param>
+        /// <exception cref="InvalidOperationException">If <see cref="Func"/> is not set.</exception>
         /// <returns>Whatever the function decides to return of type `R`.</returns>
         public virtual R Call(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5)
         {
-            if (Func != null)
-            {
-                return Func(t1, t2, t3, t4, t5);
-            }
+            if (Func == null)
+                throw new InvalidOperationException("Either set Func or override the Call method.");
 
-            throw new Exception("Either set Func or override the Call method.");
+            return Func(t1, t2, t3, t4, t5);
         }
 
         /// <summary>

--- a/Packages/Core/Runtime/Listeners/AtomListener.cs
+++ b/Packages/Core/Runtime/Listeners/AtomListener.cs
@@ -93,8 +93,8 @@ namespace UnityAtoms
                 if(_operator == AtomConditionOperators.And && !shouldRespond) return;
                 if(_operator == AtomConditionOperators.Or  &&  shouldRespond) break;
             }
-            
-            if(! shouldRespond) return;
+
+            if(!shouldRespond) return;
 
             _unityEventResponse?.Invoke(item);
             for (int i = 0; _actionResponses != null && i < _actionResponses.Count; ++i)
@@ -104,13 +104,9 @@ namespace UnityAtoms
                 if (action == null) continue;
 
                 if (action is AtomAction<T> actionWithParam)
-                {
                     actionWithParam.Do(item);
-                }
                 else
-                {
                     action.Do();
-                }
             }
         }
 

--- a/Packages/Core/Runtime/MonoBehaviourHelpers/VariableResetter.cs
+++ b/Packages/Core/Runtime/MonoBehaviourHelpers/VariableResetter.cs
@@ -15,10 +15,8 @@ namespace UnityAtoms
 
         void OnEnable()
         {
-            for (var i = 0; i < _variables.Count; ++i)
-            {
-                _variables[i].ResetValue(true);
-            }
+            foreach (AtomBaseVariable variable in _variables)
+                variable.ResetValue(true);
         }
     }
 }

--- a/Packages/Core/Runtime/Observables/BaseObservable.cs
+++ b/Packages/Core/Runtime/Observables/BaseObservable.cs
@@ -5,7 +5,7 @@ namespace UnityAtoms
 {
     public abstract class BaseObservable<T> : IObservable<T>
     {
-        protected List<IObserver<T>> _observers = new List<IObserver<T>>();
+        protected readonly List<IObserver<T>> _observers = new List<IObserver<T>>();
 
         protected abstract bool IsCompleted { get; }
 
@@ -13,26 +13,22 @@ namespace UnityAtoms
         {
             if (!_observers.Contains(observer))
                 _observers.Add(observer);
+
             return new ObservableUnsubscriber<T>(_observers, observer);
         }
 
         protected void OnCompleted()
         {
-            if (IsCompleted)
-            {
-                for (int i = 0; _observers != null && i < _observers.Count; ++i)
-                {
-                    _observers[i].OnCompleted();
-                }
-            }
+            if (!IsCompleted) return;
+
+            for (int i = 0; _observers != null && i < _observers.Count; ++i)
+                _observers[i].OnCompleted();
         }
 
         protected void OnError(Exception e)
         {
             for (int i = 0; _observers != null && i < _observers.Count; ++i)
-            {
                 _observers[i].OnError(e);
-            }
         }
     }
 }

--- a/Packages/Core/Runtime/Observables/ObservableEvent.cs
+++ b/Packages/Core/Runtime/Observables/ObservableEvent.cs
@@ -5,8 +5,8 @@ namespace UnityAtoms
 {
     public class ObservableEvent<T> : IObservable<T>
     {
-        private Action<Action<T>> _unregister;
-        private List<IObserver<T>> _observers = new List<IObserver<T>>();
+        private readonly Action<Action<T>> _unregister;
+        private readonly List<IObserver<T>> _observers = new List<IObserver<T>>();
 
         public ObservableEvent(Action<Action<T>> register, Action<Action<T>> unregister)
         {
@@ -16,25 +16,21 @@ namespace UnityAtoms
 
         ~ObservableEvent()
         {
-            if (_unregister != null)
-            {
-                _unregister(NotifyObservers);
-            }
+            _unregister?.Invoke(NotifyObservers);
         }
 
         public IDisposable Subscribe(IObserver<T> observer)
         {
             if (!_observers.Contains(observer))
                 _observers.Add(observer);
+
             return new ObservableUnsubscriber<T>(_observers, observer);
         }
 
         private void NotifyObservers(T value)
         {
             for (int i = 0; _observers != null && i < _observers.Count; ++i)
-            {
                 _observers[i].OnNext(value);
-            }
         }
     }
 }

--- a/Packages/Core/Runtime/Observables/ObservableUnsubscriber.cs
+++ b/Packages/Core/Runtime/Observables/ObservableUnsubscriber.cs
@@ -5,21 +5,19 @@ namespace UnityAtoms
 {
     public class ObservableUnsubscriber<T> : IDisposable
     {
-        private List<IObserver<T>> _observers;
-        private IObserver<T> _observer;
+        private readonly List<IObserver<T>> _observers;
+        private readonly IObserver<T> _observer;
 
         public ObservableUnsubscriber(List<IObserver<T>> observers, IObserver<T> observer)
         {
-            this._observers = observers;
-            this._observer = observer;
+            _observers = observers;
+            _observer = observer;
         }
 
         public void Dispose()
         {
             if (_observer != null && _observers.Contains(_observer))
-            {
                 _observers.Remove(_observer);
-            }
         }
     }
 }

--- a/Packages/Core/Runtime/Observables/ObservableVoidEvent.cs
+++ b/Packages/Core/Runtime/Observables/ObservableVoidEvent.cs
@@ -5,8 +5,8 @@ namespace UnityAtoms
 {
     public class ObservableVoidEvent : IObservable<Void>
     {
-        private Action<Action> _unregister = default(Action<Action>);
-        private List<IObserver<Void>> _observers = new List<IObserver<Void>>();
+        private readonly Action<Action> _unregister = default(Action<Action>);
+        private readonly List<IObserver<Void>> _observers = new List<IObserver<Void>>();
 
         public ObservableVoidEvent(Action<Action> register, Action<Action> unregister)
         {
@@ -15,25 +15,21 @@ namespace UnityAtoms
 
         ~ObservableVoidEvent()
         {
-            if (_unregister != null)
-            {
-                _unregister(NotifyObservers);
-            }
+            _unregister?.Invoke(NotifyObservers);
         }
 
         public IDisposable Subscribe(IObserver<Void> observer)
         {
             if (!_observers.Contains(observer))
                 _observers.Add(observer);
+
             return new ObservableUnsubscriber<Void>(_observers, observer);
         }
 
         private void NotifyObservers()
         {
             for (int i = 0; _observers != null && i < _observers.Count; ++i)
-            {
                 _observers[i].OnNext(new Void());
-            }
         }
     }
 }

--- a/Packages/Core/Runtime/References/AtomBaseReference.cs
+++ b/Packages/Core/Runtime/References/AtomBaseReference.cs
@@ -37,7 +37,6 @@ namespace UnityAtoms
         /// <summary>
         /// Describes how we use the Reference and where the value comes from.
         /// </summary>
-        [SerializeField]
         protected int _usage;
     }
 }


### PR DESCRIPTION
Fixes #265. Whilst I was working on some utils for Unity-Atoms today and did a little [Boy Scouting](https://www.oreilly.com/library/view/97-things-every/9780596809515/ch08.html) whilst in the process.

Most of the focus was around AtomEvent and AtomEventBase as those had some glaring "noise" in them. Overall, I did the following:

- Fixed typos.
- Added doc blocks for every method and property.
- Simplified clearing all the delegates when exiting play mode.
- Reduced nesting in some longer methods.
- Made a handful of private properties _readonly_ where applicable.
- Avoid null check against value type in IListExtensions.First().
- Throw InvalidOperationException in AtomFunction.cs as per .NET guidelines (https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/using-standard-exception-types).
- Use `foreach` in VariableResetter.cs. `foreach` doesn't generate garbage when iterating over List<> since Unity 5.6.
- Reduced nesting in Observables.