### PR TITLE
#269 Fix ChangedOnOnEnable not triggered

### DIFF
--- a/Packages/Core/Runtime/Variables/AtomVariable.cs
+++ b/Packages/Core/Runtime/Variables/AtomVariable.cs
@@ -177,12 +177,18 @@ namespace UnityAtoms
         /// </summary>
         public void TriggerInitialEvents()
         {
-            if (Changed != null && _triggerChangedOnOnEnable)
+            if (_triggerChangedOnOnEnable)
             {
+                if (Changed == null)
+                    GetOrCreateEvent<E1>();
+
                 Changed.Raise(Value);
             }
-            if (ChangedWithHistory != null && _triggerChangedWithHistoryOnOnEnable)
+            if (_triggerChangedWithHistoryOnOnEnable)
             {
+                if(ChangedWithHistory == null)
+                    GetOrCreateEvent<E2>();
+
                 var pair = default(P);
                 pair.Item1 = _value;
                 pair.Item2 = _oldValue;


### PR DESCRIPTION
This commit is a possible solution for #269

When using an Event Reference Listener with a variable, GetOrCreateEvent() is sometimes called after TriggerInitialEvents(). This commit is a way to solve this.