### PR TITLE
Fixed specifying package dependencies

### DIFF
--- a/Packages/BaseAtoms/package.json
+++ b/Packages/BaseAtoms/package.json
@@ -20,6 +20,8 @@
     "/Documentation.meta"
   ],
   "dependencies": {
+    "com.unity.modules.physics": "1.0.0",
+    "com.unity.modules.physics2d": "1.0.0",
     "com.unity-atoms.unity-atoms-core": "4.4.3"
   }
 }

--- a/Packages/Core/package.json
+++ b/Packages/Core/package.json
@@ -22,5 +22,8 @@
     "/Editor/UnityAtoms.UnityAtomsCore.Editor.asmdef.meta",
     "/Documentation",
     "/Documentation.meta"
-  ]
+  ],
+  "dependencies": {
+    "com.unity.modules.uielements": "1.0.0"
+  }
 }

--- a/Packages/Mobile/package.json
+++ b/Packages/Mobile/package.json
@@ -20,6 +20,7 @@
     "/Documentation.meta"
   ],
   "dependencies": {
-    "com.unity-atoms.unity-atoms-core": "4.4.3"
+    "com.unity-atoms.unity-atoms-core": "4.4.3",
+    "com.unity-atoms.unity-atoms-base-atoms": "4.4.3"
   }
 }

--- a/Packages/MonoHooks/package.json
+++ b/Packages/MonoHooks/package.json
@@ -20,6 +20,7 @@
     "/Documentation.meta"
   ],
   "dependencies": {
+    "com.unity.ugui": "1.0.0",
     "com.unity-atoms.unity-atoms-core": "4.4.3",
     "com.unity-atoms.unity-atoms-base-atoms": "4.4.3"
   }


### PR DESCRIPTION
Dependencies to built-in packages and other Atoms packages are now correctly specified.
Fixes #283 .