### PR TITLE
Revert "#271 Use event references in VoidHook and OnAwakeHook"

### DIFF
--- a/Packages/MonoHooks/Runtime/Hooks/OnAwakeHook.cs
+++ b/Packages/MonoHooks/Runtime/Hooks/OnAwakeHook.cs
@@ -25,13 +25,13 @@ namespace UnityAtoms.MonoHooks
         private void Awake()
         {
             // This is needed because it's not certain that OnEnable on all scripts are called before Awake on all scripts
-            if (_eventReference != null && _listener != null)
+            if (_event != null && _listener != null)
             {
-                _eventReference.Event.RegisterListener(_listener);
+                _event.RegisterListener(_listener);
             }
             if (_eventWithGameObjectReference != null && _gameObjectListener != null)
             {
-                _eventWithGameObjectReference.Event.RegisterListener(_gameObjectListener);
+                _eventWithGameObjectReference.RegisterListener(_gameObjectListener);
             }
 
             OnHook();

--- a/Packages/MonoHooks/Runtime/Hooks/VoidHook.cs
+++ b/Packages/MonoHooks/Runtime/Hooks/VoidHook.cs
@@ -13,13 +13,13 @@ namespace UnityAtoms.MonoHooks
         /// The Event
         /// </summary>
         [SerializeField]
-        protected VoidBaseEventReference _eventReference;
+        protected VoidEvent _event;
 
         /// <summary>
         /// Event including a GameObject reference.
         /// </summary>
         [SerializeField]
-        protected GameObjectEventReference _eventWithGameObjectReference;
+        protected GameObjectEvent _eventWithGameObjectReference;
 
         /// <summary>
         /// Selector function for the Event `EventWithGameObjectReference`. Makes it possible to for example select the parent GameObject and pass that a long to the `EventWithGameObjectReference`.
@@ -29,13 +29,13 @@ namespace UnityAtoms.MonoHooks
 
         protected void OnHook()
         {
-            if (_eventReference != null && _eventReference.Event != null)
+            if (_event != null)
             {
-                _eventReference.Event.Raise();
+                _event.Raise();
             }
-            if (_eventWithGameObjectReference != null && _eventWithGameObjectReference.Event != null)
+            if (_eventWithGameObjectReference != null)
             {
-                _eventWithGameObjectReference.Event.Raise(_selectGameObjectReference != null ? _selectGameObjectReference.Call(gameObject) : gameObject);
+                _eventWithGameObjectReference.Raise(_selectGameObjectReference != null ? _selectGameObjectReference.Call(gameObject) : gameObject);
             }
         }
     }


### PR DESCRIPTION
Reverts unity-atoms/unity-atoms#272 because it is a breaking change and belongs into v5.