### PR TITLE
Fix hasChildren display in AtomReferences

### DIFF
--- a/Packages/Core/Editor/Drawers/AtomBaseReferenceDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomBaseReferenceDrawer.cs
@@ -67,16 +67,12 @@ namespace UnityAtoms.Editor
             var newUsageValue = EditorGUI.Popup(buttonRect, currentUsage.intValue, GetPopupOptions(property), _popupStyle);
             currentUsage.intValue = newUsageValue;
 
-
             var usageTypePropertyName = GetUsages(property)[newUsageValue].PropertyName;
             var usageTypeProperty = property.FindPropertyRelative(usageTypePropertyName);
 
-
-            var valueFieldHeight = EditorGUI.GetPropertyHeight(property.FindPropertyRelative(usageTypePropertyName), label);
-
-            if (usageTypePropertyName == "_value" && valueFieldHeight > EditorGUIUtility.singleLineHeight+2)
+            if (usageTypePropertyName == "_value")
             {
-                EditorGUI.PropertyField(originalPosition, usageTypeProperty, GUIContent.none, true);
+                EditorGUI.PropertyField(usageTypeProperty.hasChildren ? originalPosition : position, usageTypeProperty, GUIContent.none, true);
             }
             else
             {


### PR DESCRIPTION
The display of an AtomReference would act a bit weird if the Atom was of e.g. a serializable class.

Old: open button is displayed weirdly on top of the selection button.
![Screenshot 2021-07-09 141001](https://user-images.githubusercontent.com/27729987/125075864-73bbe080-e0bf-11eb-8c97-c091df184f9a.png)

New: open button is displayed at the original position. 
![Screenshot 2021-07-09 141028](https://user-images.githubusercontent.com/27729987/125075959-9221dc00-e0bf-11eb-9e9a-8fa5e7097635.png)

Since the EditorGUI.PropertyField in question has GUIContent.none, I do not expect this to break any other displays.