### PR TITLE
add missing scoped registry in install docs

### DIFF
--- a/docs/introduction/installation.md
+++ b/docs/introduction/installation.md
@@ -28,7 +28,8 @@ Add the following to your `manifest.json`:
                 "com.unity-atoms.unity-atoms-mono-hooks",
                 "com.unity-atoms.unity-atoms-tags",
                 "com.unity-atoms.unity-atoms-scene-mgmt",
-                "com.unity-atoms.unity-atoms-ui"
+                "com.unity-atoms.unity-atoms-ui",
+                "com.unity-atoms.unity-atoms-input-system"
             ]
         }
     ],


### PR DESCRIPTION
added to prevent unity from raising missing dependency error.