### PR TITLE
Fix #296 FiniteStateMachine not listening to Raise Event To Complete Transitio…

### DIFF
--- a/Packages/FSM/Runtime/FiniteStateMachine/FiniteStateMachine.cs
+++ b/Packages/FSM/Runtime/FiniteStateMachine/FiniteStateMachine.cs
@@ -270,6 +270,7 @@ namespace UnityAtoms.FSM
                 if (transition.TestCondition())
                 {
                     _currentTransition = transition;
+                    transition.Begin(this, EndCurrentTransition);
                     if (_transitionStarted != null)
                     {
                         _transitionStarted.Raise(
@@ -282,7 +283,6 @@ namespace UnityAtoms.FSM
                             }
                         );
                     }
-                    transition.Begin(this, EndCurrentTransition);
                 }
             }
             else


### PR DESCRIPTION
When using FSM with Raise Event To Complete Transition on, and doing a manual raise ( triggered by TransitionStart.Raise), the Complete Raise is missed.

After reviewing the FSM code, I was able to fix it by calling the method that registers the listener BEFORE the Raise of Transition start at FiniteStateMachine.cs#285:
Before the fix:
if (transition.TestCondition()) { _currentTransition = transition; if (_transitionStarted != null) { _transitionStarted.Raise( new FSMTransitionData() { FromState = transition.FromState, ToState = transition.ToState, Command = transition.Command, CompleteTransition = _completeCurrentTransition, } ); } **transition.Begin(this, EndCurrentTransition);** }

After the fix:
if (transition.TestCondition()) { _currentTransition = transition; transition.Begin(this, EndCurrentTransition); if (_transitionStarted != null) { _transitionStarted.Raise( new FSMTransitionData() { FromState = transition.FromState, ToState = transition.ToState, Command = transition.Command, CompleteTransition = _completeCurrentTransition, } ); } }

Basicaly transition.Begin calls _fsmReference.CompleteCurrentTransition.RegisterListener(this); and _transitionStarted.Raise will Raise this event. So if the register happens after the raise, it wont be listening.