### PR TITLE
Fixed collection deserialization problem.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 # 4.4.4 (TODO: UPDATE THE DATE ON MERGE DAY)
 
+## 🐛 Bug fixes
+
+-   [#300](https://github.com/unity-atoms/unity-atoms/pull/300) Fixed Serialization on AtomCollections.
+
 ## 📝 Documentation
 
 -   A "Smooth Workflow" section has been added under the CONTRIBUTING.md to explain how one can easily start contributing to Atoms whilst working from inside Unity. This was an issue as the atoms repository is not naturally compatible with Unity. ([@Casey-Hofland](https://github.com/Casey-Hofland))

--- a/Packages/BaseAtoms/Runtime/Collections/AtomCollection.cs
+++ b/Packages/BaseAtoms/Runtime/Collections/AtomCollection.cs
@@ -53,6 +53,11 @@ namespace UnityAtoms.BaseAtoms
         void OnDisable()
         {
             if (Value == null) return;
+			
+			//Calling OnAfterDeserialize again here, as Collection may use StringConstant or StringVariable as key, and Unity doesnt ensures execution order in Scriptable Objects
+            // As such is possible that the Collection is called before its keys are ready to be used.
+            // On OnEnable, all atoms are supposed to already have been initialized, and calling OnAfterDeserialize, will fix any issue with not ready keys
+            Value.OnAfterDeserialize();
 
             Value.Added -= PropogateAdded;
             Value.Removed -= PropogateRemoved;


### PR DESCRIPTION
Calling OnAfterDeserialize again, as Collection may use StringConstant or StringVariable as key, and Unity doesnt ensures execution order in Scriptable Objects
As such is possible that the Collection is called before its keys are ready to be used.
On OnEnable, all atoms are supposed to already have been initialized, and calling OnAfterDeserialize, will fix any issue with not ready keys 

#299 