### PR TITLE
fix #305 empty list of tagged objects throws NRE

### DIFF
--- a/Packages/Tags/Runtime/AtomTags.cs
+++ b/Packages/Tags/Runtime/AtomTags.cs
@@ -199,6 +199,7 @@ namespace UnityAtoms.Tags
         public static GameObject FindByTag(string tag)
         {
             if (!TaggedGameObjects.ContainsKey(tag)) return null;
+            if (TaggedGameObjects.Count < 1) return null;
             return TaggedGameObjects[tag][0];
         }
 

--- a/Packages/Tags/Runtime/AtomTags.cs
+++ b/Packages/Tags/Runtime/AtomTags.cs
@@ -199,7 +199,7 @@ namespace UnityAtoms.Tags
         public static GameObject FindByTag(string tag)
         {
             if (!TaggedGameObjects.ContainsKey(tag)) return null;
-            if (TaggedGameObjects.Count < 1) return null;
+            if (TaggedGameObjects[tag].Count < 1) return null;
             return TaggedGameObjects[tag][0];
         }
 


### PR DESCRIPTION
in case no object was tagged FindByTag threw an exception instead of returning null.