### PR TITLE
Fix #255 AtomVariableInstancer assumes Base != null

### DIFF
--- a/Packages/Core/Runtime/VariableInstancers/AtomVariableInstancer.cs
+++ b/Packages/Core/Runtime/VariableInstancers/AtomVariableInstancer.cs
@@ -29,22 +29,14 @@ namespace UnityAtoms
         /// </summary>
         protected override void ImplSpecificSetup()
         {
-            if(Base != null)
+            if (Base.Changed != null)
             {
-                if (Base.Changed != null)
-                {
-                    _inMemoryCopy.Changed = Instantiate(Base.Changed);
-                }
-
-                if (Base.ChangedWithHistory != null)
-                {
-                    _inMemoryCopy.ChangedWithHistory = Instantiate(Base.ChangedWithHistory);
-                }
+                _inMemoryCopy.Changed = Instantiate(Base.Changed);
             }
-            else
+
+            if (Base.ChangedWithHistory != null)
             {
-                _inMemoryCopy.Changed = _inMemoryCopy.GetOrCreateEvent<E1>();
-                _inMemoryCopy.ChangedWithHistory = _inMemoryCopy.GetOrCreateEvent<E2>();
+                _inMemoryCopy.ChangedWithHistory = Instantiate(Base.ChangedWithHistory);
             }
 
             // Manually trigger initial events since base class has already instantiated Variable 

--- a/Packages/Core/Runtime/VariableInstancers/AtomVariableInstancer.cs
+++ b/Packages/Core/Runtime/VariableInstancers/AtomVariableInstancer.cs
@@ -29,14 +29,22 @@ namespace UnityAtoms
         /// </summary>
         protected override void ImplSpecificSetup()
         {
-            if (Base.Changed != null)
+            if(Base != null)
             {
-                _inMemoryCopy.Changed = Instantiate(Base.Changed);
-            }
+                if (Base.Changed != null)
+                {
+                    _inMemoryCopy.Changed = Instantiate(Base.Changed);
+                }
 
-            if (Base.ChangedWithHistory != null)
+                if (Base.ChangedWithHistory != null)
+                {
+                    _inMemoryCopy.ChangedWithHistory = Instantiate(Base.ChangedWithHistory);
+                }
+            }
+            else
             {
-                _inMemoryCopy.ChangedWithHistory = Instantiate(Base.ChangedWithHistory);
+                _inMemoryCopy.Changed = _inMemoryCopy.GetOrCreateEvent<E1>();
+                _inMemoryCopy.ChangedWithHistory = _inMemoryCopy.GetOrCreateEvent<E2>();
             }
 
             // Manually trigger initial events since base class has already instantiated Variable 


### PR DESCRIPTION
The null check on Base events in AtomVariableInstancer didn't account for Base itself and didnt create runtime AtomEvents. 