### PR TITLE
Fix #268 [BUG] Void Event Instancer stops working after deactivate / activate cycle

### DIFF
--- a/Packages/Core/Runtime/EventInstancers/AtomEventInstancer.cs
+++ b/Packages/Core/Runtime/EventInstancers/AtomEventInstancer.cs
@@ -46,7 +46,7 @@ namespace UnityAtoms
             {
                 _inMemoryCopy = ScriptableObject.CreateInstance<E>();
             }
-            else
+            else if(_inMemoryCopy == null)
             {
                 _inMemoryCopy = Instantiate(_base);
             }

--- a/Packages/Core/Runtime/VariableInstancers/AtomBaseVariableInstancer.cs
+++ b/Packages/Core/Runtime/VariableInstancers/AtomBaseVariableInstancer.cs
@@ -53,7 +53,7 @@ namespace UnityAtoms
             {
                 _inMemoryCopy = ScriptableObject.CreateInstance<V>();
             }
-            else
+            else if(_inMemoryCopy == null)
             {
                 _inMemoryCopy = Instantiate(Base);
             }


### PR DESCRIPTION
When the GameObject that contained the event/variable instancer was disabled and re enabled, a new _inMemoryCopy was instantiated and the old one overriden. The listeners however were still listening to the overriden one. By checking if theres already an _inMemoryCopy in the scene this bug can be solved.

One thing that i'm not sure what to do with. If the user destroys the event/variable instancer component or GameObject, do we have to Unregister these listener as Unity Atoms or do we let this "error" up to the user? Also what do we do with the listeners that now won't listen to something anymore?