### PR TITLE
fix #254 [BUG] ulong variable throws error when the value being edited in play mode.

### DIFF
--- a/Packages/Core/Editor/Editors/Variables/AtomVariableEditor.cs
+++ b/Packages/Core/Editor/Editors/Variables/AtomVariableEditor.cs
@@ -48,6 +48,11 @@ namespace UnityAtoms.Editor
                         {
                             atomTarget.BaseValue = (double)(float)value;
                         }
+                        //Ulong is deserialized to System32 Int. 
+                        else if(typeof(T) == typeof(ulong))
+                        {
+                            atomTarget.BaseValue = (ulong)(int)value;
+                        }
                         else
                         {
                             atomTarget.BaseValue = value;


### PR DESCRIPTION
Ulong was deserialized to a System32 int. The solution was to use the same fix as for the Double type which was serialized to a float. I guess more of these issues might appear in the future so then this fix might become quite a long bit of code