### PR TITLE
fix #282 changed/changedwithhistory events not created when registere…

### DIFF
--- a/Packages/Core/Runtime/Variables/AtomVariable.cs
+++ b/Packages/Core/Runtime/Variables/AtomVariable.cs
@@ -52,6 +52,7 @@ namespace UnityAtoms
         {
             get
             {
+                GetOrCreateEvent<E1>();
                 return _changed;
             }
             set
@@ -71,6 +72,7 @@ namespace UnityAtoms
         {
             get
             {
+                GetOrCreateEvent<E2>();
                 return _changedWithHistory;
             }
             set
@@ -378,25 +380,25 @@ namespace UnityAtoms
         {
             if (typeof(E) == typeof(E1))
             {
-                if (Changed == null)
+                if (_changed == null)
                 {
-                    Changed = ScriptableObject.CreateInstance<E1>();
-                    Changed.name = $"{(String.IsNullOrWhiteSpace(name) ? "" : $"{name}_")}ChangedEvent_Runtime_{typeof(E1)}";
+                    _changed = ScriptableObject.CreateInstance<E1>();
+                    _changed.name = $"{(String.IsNullOrWhiteSpace(name) ? "" : $"{name}_")}ChangedEvent_Runtime_{typeof(E1)}";
                     _changedInstantiatedAtRuntime = true;
                 }
 
-                return Changed as E;
+                return _changed as E;
             }
             if (typeof(E) == typeof(E2))
             {
-                if (ChangedWithHistory == null)
+                if (_changedWithHistory == null)
                 {
-                    ChangedWithHistory = ScriptableObject.CreateInstance<E2>();
-                    ChangedWithHistory.name = $"{(String.IsNullOrWhiteSpace(name) ? "" : $"{name}_")}_ChangedWithHistoryEvent_Runtime_{typeof(E2)}";
+                    _changedWithHistory = ScriptableObject.CreateInstance<E2>();
+                    _changedWithHistory.name = $"{(String.IsNullOrWhiteSpace(name) ? "" : $"{name}_")}_ChangedWithHistoryEvent_Runtime_{typeof(E2)}";
                     _changedWithHistoryInstantiatedAtRuntime = true;
                 }
 
-                return ChangedWithHistory as E;
+                return _changedWithHistory as E;
             }
 
             throw new NotSupportedException($"Event type {typeof(E)} not supported! Use {typeof(E1)} or {typeof(E2)}.");


### PR DESCRIPTION
The problem was indeed that the changed and changedWithHistory events where not created when called in code. There are 3 possible solutions I can come up with to fix this bug. One is to slightly modify the GetOrCreate<E>() method so it can be called in the property. 

Option two is to call the runtime creation code in the property itself again. This makes the GetOrCreate<E>() method unnessesary I think?

Option 3 is to somehow add an usage for calling a variables events in code

Maybe another solution will work better than what I suggested here in this PR. Im all open for the best suggestion to tackle this problem and to update this PR.