### PR TITLE
fix #237 Drawer tries to create field for public Action

### DIFF
--- a/Packages/Core/Editor/Extensions/SerializedPropertyExtensions.cs
+++ b/Packages/Core/Editor/Extensions/SerializedPropertyExtensions.cs
@@ -24,7 +24,10 @@ namespace UnityAtoms.Editor
             {
                 try
                 {
-                    field.SetValue(box, property.FindPropertyRelative(field.Name).GetPropertyValue());
+                    if (!field.Attributes.HasFlag(FieldAttributes.NotSerialized))
+                    {
+                        field.SetValue(box, property.FindPropertyRelative(field.Name).GetPropertyValue());
+                    }
                 }
                 catch (InvalidOperationException)
                 {


### PR DESCRIPTION
The value property inside an AtomVariable is used with the Unity JsonUtility to make sure changes are working properly. There was no check for the System.NonSerialized attribute. This made it igonre that attribute only on the AtomVariable value property. By adding this check the System.NonSerialized attrbute also gets respected in the value. It was already working with this attribute on the C# action in the initialValue. 