### PR TITLE
Remove extra underscore from ChangedHistoryEvent name

### DIFF
--- a/Packages/Core/Runtime/Variables/AtomVariable.cs
+++ b/Packages/Core/Runtime/Variables/AtomVariable.cs
@@ -394,7 +394,7 @@ namespace UnityAtoms
                 if (_changedWithHistory == null)
                 {
                     _changedWithHistory = ScriptableObject.CreateInstance<E2>();
-                    _changedWithHistory.name = $"{(String.IsNullOrWhiteSpace(name) ? "" : $"{name}_")}_ChangedWithHistoryEvent_Runtime_{typeof(E2)}";
+                    _changedWithHistory.name = $"{(String.IsNullOrWhiteSpace(name) ? "" : $"{name}_")}ChangedWithHistoryEvent_Runtime_{typeof(E2)}";
                     _changedWithHistoryInstantiatedAtRuntime = true;
                 }
 


### PR DESCRIPTION
There was an extra underscore in the name of Changed With History runtime generated event.