### PR TITLE
#149 [FEATURE] Create button in variables create events as nested scriptable objects (initial implementation).

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -1,0 +1,6 @@
+﻿{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Workload.ManagedGame"
+  ]
+}

--- a/Packages/BaseAtoms/Editor/SubAssetDragAndDrop.cs
+++ b/Packages/BaseAtoms/Editor/SubAssetDragAndDrop.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace UnityAtoms.Editor
 {
-    //code found at: https://github.com/Maligan/unity-subassets-drag-and-drop/blob/master/SubAssetDragAndDrop.cs
+    //Code found at: https://github.com/Maligan/unity-subassets-drag-and-drop/blob/master/SubAssetDragAndDrop.cs and modified.
     [InitializeOnLoad]
     public static class SubAssetDragAndDrop
     {
@@ -17,28 +17,40 @@ namespace UnityAtoms.Editor
 
         private static void OnProjectWindowItemOnGUI(string guid, Rect selectionRect)
         {
-            // Break - key modifier doen't pressed
+            // Break - key modifier is not pressed
             var activated = Event.current.alt;
-            if (activated == false) return;
+            if (activated == false)
+                return;
 
             // Break - OnGUI() call not for mouse target
             var within = selectionRect.Contains(Event.current.mousePosition);
-            if (within == false) return;
+            if (within == false)
+                return;
 
             // Break - destination match one of sources 
             var target = AssetDatabase.GUIDToAssetPath(guid);
             var targetInSources = Array.IndexOf(DragAndDrop.paths, target) != -1;
-            if (targetInSources) return;
+            if (targetInSources)
+                return;
 
             // Break - unity default moving
             var targetIsFolder = AssetDatabase.IsValidFolder(target);
             if (targetIsFolder)
+            {
                 foreach (var asset in DragAndDrop.objectReferences)
-                    if (AssetDatabase.IsMainAsset(asset)) return;
+                {
+                    if (AssetDatabase.IsMainAsset(asset))
+                        return;
+                }
+            }
+                
 
             // Break - there is Unity restriction to use GameObjects as SubAssets
             foreach (var obj in DragAndDrop.objectReferences)
-                if (obj is GameObject) return;
+            {
+                if (obj is GameObject)
+                    return;
+            }
 
             if (Event.current.type == EventType.DragUpdated)
             {
@@ -55,23 +67,27 @@ namespace UnityAtoms.Editor
 
         private static void Move(IEnumerable<UnityEngine.Object> sources, string destinationPath)
         {
-            var destinationIsFolder = AssetDatabase.IsValidFolder(destinationPath);
-
             foreach (var source in sources)
             {
                 var sourcePath = AssetDatabase.GetAssetPath(source);
                 var sourceIsMain = AssetDatabase.IsMainAsset(source);
                 var sourceAssets = new List<UnityEngine.Object>() { source };
                 if (sourceIsMain)
+                {
                     sourceAssets.AddRange(AssetDatabase.LoadAllAssetRepresentationsAtPath(sourcePath));
+                }
 
                 // Peform move assets from source file to destination
                 foreach (var asset in sourceAssets)
+                {
                     MoveAsset(asset, destinationPath);
+                }
 
                 // Remove asset file if it is empty now
                 if (sourceIsMain)
+                {
                     AssetDatabase.DeleteAsset(sourcePath);
+                }
             }
 
             AssetDatabase.SaveAssets();
@@ -111,10 +127,14 @@ namespace UnityAtoms.Editor
         private static List<UnityEngine.Object> GetHiddenReferences(UnityEngine.Object asset, string refsPath = null, List<UnityEngine.Object> refs = null)
         {
             if (refsPath == null)
+            {
                 refsPath = AssetDatabase.GetAssetPath(asset);
+            }
 
             if (refs == null)
+            {
                 refs = new List<UnityEngine.Object>();
+            }
 
             var iterator = new SerializedObject(asset).GetIterator();
             while (iterator.Next(true))

--- a/Packages/BaseAtoms/Editor/SubAssetDragAndDrop.cs
+++ b/Packages/BaseAtoms/Editor/SubAssetDragAndDrop.cs
@@ -6,7 +6,9 @@ using UnityEngine;
 
 namespace UnityAtoms.Editor
 {
-    //Code found at: https://github.com/Maligan/unity-subassets-drag-and-drop/blob/master/SubAssetDragAndDrop.cs and modified.
+    /// <summary>
+    /// Code found at: https://github.com/Maligan/unity-subassets-drag-and-drop/blob/master/SubAssetDragAndDrop.cs and modified.
+    /// </summary>
     [InitializeOnLoad]
     public static class SubAssetDragAndDrop
     {
@@ -124,7 +126,10 @@ namespace UnityAtoms.Editor
             }
         }
 
-        private static List<UnityEngine.Object> GetHiddenReferences(UnityEngine.Object asset, string refsPath = null, List<UnityEngine.Object> refs = null)
+        private static List<UnityEngine.Object> GetHiddenReferences(
+            UnityEngine.Object asset,
+            string refsPath = null,
+            List<UnityEngine.Object> refs = null)
         {
             if (refsPath == null)
             {

--- a/Packages/BaseAtoms/Editor/SubAssetDragAndDrop.cs
+++ b/Packages/BaseAtoms/Editor/SubAssetDragAndDrop.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+namespace UnityAtoms.Editor
+{
+    //code found at: https://github.com/Maligan/unity-subassets-drag-and-drop/blob/master/SubAssetDragAndDrop.cs
+    [InitializeOnLoad]
+    public static class SubAssetDragAndDrop
+    {
+        static SubAssetDragAndDrop()
+        {
+            EditorApplication.projectWindowItemOnGUI += OnProjectWindowItemOnGUI;
+        }
+
+        private static void OnProjectWindowItemOnGUI(string guid, Rect selectionRect)
+        {
+            // Break - key modifier doen't pressed
+            var activated = Event.current.alt;
+            if (activated == false) return;
+
+            // Break - OnGUI() call not for mouse target
+            var within = selectionRect.Contains(Event.current.mousePosition);
+            if (within == false) return;
+
+            // Break - destination match one of sources 
+            var target = AssetDatabase.GUIDToAssetPath(guid);
+            var targetInSources = Array.IndexOf(DragAndDrop.paths, target) != -1;
+            if (targetInSources) return;
+
+            // Break - unity default moving
+            var targetIsFolder = AssetDatabase.IsValidFolder(target);
+            if (targetIsFolder)
+                foreach (var asset in DragAndDrop.objectReferences)
+                    if (AssetDatabase.IsMainAsset(asset)) return;
+
+            // Break - there is Unity restriction to use GameObjects as SubAssets
+            foreach (var obj in DragAndDrop.objectReferences)
+                if (obj is GameObject) return;
+
+            if (Event.current.type == EventType.DragUpdated)
+            {
+                DragAndDrop.visualMode = DragAndDropVisualMode.Move;
+                Event.current.Use();
+            }
+            else if (Event.current.type == EventType.DragPerform)
+            {
+                Move(DragAndDrop.objectReferences, target);
+                DragAndDrop.AcceptDrag();
+                Event.current.Use();
+            }
+        }
+
+        private static void Move(IEnumerable<UnityEngine.Object> sources, string destinationPath)
+        {
+            var destinationIsFolder = AssetDatabase.IsValidFolder(destinationPath);
+
+            foreach (var source in sources)
+            {
+                var sourcePath = AssetDatabase.GetAssetPath(source);
+                var sourceIsMain = AssetDatabase.IsMainAsset(source);
+                var sourceAssets = new List<UnityEngine.Object>() { source };
+                if (sourceIsMain)
+                    sourceAssets.AddRange(AssetDatabase.LoadAllAssetRepresentationsAtPath(sourcePath));
+
+                // Peform move assets from source file to destination
+                foreach (var asset in sourceAssets)
+                    MoveAsset(asset, destinationPath);
+
+                // Remove asset file if it is empty now
+                if (sourceIsMain)
+                    AssetDatabase.DeleteAsset(sourcePath);
+            }
+
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
+        }
+
+        private static void MoveAsset(UnityEngine.Object asset, string destinationPath)
+        {
+            // Find hidden references (before source move)
+            var assetRefs = GetHiddenReferences(asset);
+
+            // Move asset
+            var destinationIsFolder = AssetDatabase.IsValidFolder(destinationPath);
+            if (destinationIsFolder)
+            {
+                var assetName = asset.name + "." + GetFileExtention(asset);
+                var assetPath = Path.Combine(destinationPath, assetName);
+                var assetUniquePath = AssetDatabase.GenerateUniqueAssetPath(assetPath);
+
+                AssetDatabase.RemoveObjectFromAsset(asset);
+                AssetDatabase.CreateAsset(asset, assetUniquePath);
+            }
+            else
+            {
+                AssetDatabase.RemoveObjectFromAsset(asset);
+                AssetDatabase.AddObjectToAsset(asset, destinationPath);
+            }
+
+            // Move attached hidden references
+            foreach (var reference in assetRefs)
+            {
+                AssetDatabase.RemoveObjectFromAsset(reference);
+                AssetDatabase.AddObjectToAsset(reference, asset);
+            }
+        }
+
+        private static List<UnityEngine.Object> GetHiddenReferences(UnityEngine.Object asset, string refsPath = null, List<UnityEngine.Object> refs = null)
+        {
+            if (refsPath == null)
+                refsPath = AssetDatabase.GetAssetPath(asset);
+
+            if (refs == null)
+                refs = new List<UnityEngine.Object>();
+
+            var iterator = new SerializedObject(asset).GetIterator();
+            while (iterator.Next(true))
+            {
+                if (iterator.propertyType == SerializedPropertyType.ObjectReference)
+                {
+                    var obj = iterator.objectReferenceValue;
+                    if (obj != null && (obj.hideFlags & HideFlags.HideInHierarchy) != 0)
+                    {
+                        if (refs.IndexOf(obj) == -1 && AssetDatabase.GetAssetPath(obj) == refsPath)
+                        {
+                            refs.Add(obj);
+                            GetHiddenReferences(obj, refsPath, refs);
+                        }
+                    }
+                }
+            }
+
+            return refs;
+        }
+
+        /// Thanks to mob-sakai (https://github.com/mob-sakai/SubAssetEditor) for full mapping list
+        private static string GetFileExtention(UnityEngine.Object obj)
+        {
+            if (obj is AnimationClip)
+                return "anim";
+            else if (obj is UnityEditor.Animations.AnimatorController)
+                return "controller";
+            else if (obj is AnimatorOverrideController)
+                return "overrideController";
+            else if (obj is Material)
+                return "mat";
+            else if (obj is Texture)
+                return "png";
+            else if (obj is ComputeShader)
+                return "compute";
+            else if (obj is Shader)
+                return "shader";
+            else if (obj is Cubemap)
+                return "cubemap";
+            else if (obj is Flare)
+                return "flare";
+            else if (obj is ShaderVariantCollection)
+                return "shadervariants";
+            else if (obj is LightmapParameters)
+                return "giparams";
+            else if (obj is GUISkin)
+                return "guiskin";
+            else if (obj is PhysicMaterial)
+                return "physicMaterial";
+            else if (obj is PhysicsMaterial2D)
+                return "physicsMaterial2D";
+            else if (obj is UnityEngine.Audio.AudioMixer)
+                return "mixer";
+            else if (obj is UnityEngine.U2D.SpriteAtlas)
+                return "spriteatlas";
+            else if (obj is TextAsset)
+                return "txt";
+            else if (obj is GameObject)
+                return "prefab";
+            else if (obj is ScriptableObject)
+                return "asset";
+
+            return null;
+        }
+    }
+}

--- a/Packages/BaseAtoms/Editor/SubAssetDragAndDrop.cs.meta
+++ b/Packages/BaseAtoms/Editor/SubAssetDragAndDrop.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 222c9d9b907c72447bc7c3c5ccf38a40
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/Core/Editor/Drawers/AtomDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomDrawer.cs
@@ -122,7 +122,7 @@ namespace UnityAtoms.Editor
                             {
                                 string path = AssetDatabase.GetAssetPath(property.serializedObject.targetObject);
                                 path = path == "" ? "Assets/" : Path.GetDirectoryName(path) + "/";
-                                // Create asset
+
                                 T so = ScriptableObject.CreateInstance<T>();
 
                                 if (property.GetParent() is BaseAtom ab)

--- a/Packages/Core/Editor/Drawers/AtomDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomDrawer.cs
@@ -125,7 +125,6 @@ namespace UnityAtoms.Editor
                                 // Create asset
                                 T so = ScriptableObject.CreateInstance<T>();
 
-                                //property.objectReferenceValue = so;
                                 if (property.GetParent() is BaseAtom ab)
                                 {
                                     so.name = drawerData.NameOfNewAtom;
@@ -184,8 +183,8 @@ namespace UnityAtoms.Editor
             {
                 if (property.GetParent() is BaseAtom ab)
                 {
-                    var x = FindSubAsset(ab, property.objectReferenceValue);
-                    if (x == null)
+                    var subAsset = FindSubAsset(ab, property.objectReferenceValue);
+                    if (subAsset == null)
                     {
                         if (GUI.Button(nestRect, "Fuse"))
                         {
@@ -232,9 +231,9 @@ namespace UnityAtoms.Editor
             AssetDatabase.Refresh();
         }
 
-        private Object FindSubAsset(Object asset, Object assetToFind)
+        private Object FindSubAsset(Object parent, Object assetToFind)
         {
-            Object[] objs = AssetDatabase.LoadAllAssetsAtPath(AssetDatabase.GetAssetPath(asset));
+            Object[] objs = AssetDatabase.LoadAllAssetsAtPath(AssetDatabase.GetAssetPath(parent));
             foreach (var item in objs)
             {
                 if(assetToFind.Equals(item))

--- a/Packages/Core/Editor/Utils/AtomFuser.cs
+++ b/Packages/Core/Editor/Utils/AtomFuser.cs
@@ -1,0 +1,77 @@
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+namespace UnityAtoms.Editor
+{
+    public static class AtomFuser
+    {
+        public static bool IsValidFuse(BaseAtom ab)
+        {
+            var variablePath = AssetDatabase.GetAssetOrScenePath(ab);
+            var destinationPath = variablePath.Replace($"/{ab.name}.asset", "");
+            if (destinationPath.EndsWith(".asset"))
+            {
+                return false;
+            }
+            else
+            {
+                return true;
+            }
+        }
+
+        public static Object FindSubAsset(Object parent, Object assetToFind)
+        {
+            Object[] objs = AssetDatabase.LoadAllAssetsAtPath(AssetDatabase.GetAssetPath(parent));
+            foreach (var item in objs)
+            {
+                if (assetToFind.Equals(item))
+                {
+                    return item;
+                }
+            }
+            return default;
+        }
+
+        public static bool IsFused(SerializedProperty property, BaseAtom ab)
+        {
+            if (FindSubAsset(ab, property.objectReferenceValue) != null)
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static void FuseAtom(SerializedProperty property, BaseAtom ab)
+        {
+            var sourceIsMain = AssetDatabase.IsMainAsset(property.objectReferenceValue);
+            var sourcePath = AssetDatabase.GetAssetPath(property.objectReferenceValue);
+            AssetDatabase.RemoveObjectFromAsset(property.objectReferenceValue);
+            AssetDatabase.AddObjectToAsset(property.objectReferenceValue, ab);
+
+            if (sourceIsMain)
+            {
+                AssetDatabase.DeleteAsset(sourcePath);
+            }
+
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
+        }
+
+        public static void DiffuseAtom(SerializedProperty property, BaseAtom ab)
+        {
+            var variablePath = AssetDatabase.GetAssetOrScenePath(ab);
+            var destinationPath = variablePath.Replace($"/{ab.name}.asset", "");
+            var assetName = property.objectReferenceValue.name + ".asset";
+            var assetPath = Path.Combine(destinationPath, assetName);
+            var assetUniquePath = AssetDatabase.GenerateUniqueAssetPath(assetPath);
+            AssetDatabase.RemoveObjectFromAsset(property.objectReferenceValue);
+            AssetDatabase.CreateAsset(property.objectReferenceValue, assetUniquePath);
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
+        }
+    }
+}

--- a/Packages/Core/Editor/Utils/AtomFuser.cs
+++ b/Packages/Core/Editor/Utils/AtomFuser.cs
@@ -23,7 +23,7 @@ namespace UnityAtoms.Editor
         public static Object FindSubAsset(Object parent, Object assetToFind)
         {
             Object[] objs = AssetDatabase.LoadAllAssetsAtPath(AssetDatabase.GetAssetPath(parent));
-            foreach (var item in objs)
+            foreach (Object item in objs)
             {
                 if (assetToFind.Equals(item))
                 {
@@ -35,14 +35,7 @@ namespace UnityAtoms.Editor
 
         public static bool IsFused(SerializedProperty property, BaseAtom ab)
         {
-            if (FindSubAsset(ab, property.objectReferenceValue) != null)
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            return FindSubAsset(ab, property.objectReferenceValue) != null;
         }
 
         public static void FuseAtom(SerializedProperty property, BaseAtom ab)

--- a/Packages/Core/Editor/Utils/AtomFuser.cs.meta
+++ b/Packages/Core/Editor/Utils/AtomFuser.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 765dd6b85b7be84428e3e5726361eac8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR adds the option to Fuse and Diffuse Atom Events to Atom variables, valueLists, instancers etc. The current implementation is shown in the video's below. NOTE: In the current design its up to the user to configure their project files the way they want. This can lead to possibly unwanted or weird situations, but thats up to the user right now.

Features:

- Fuse/Diffuse referenced events in the Drawer
- Create new standard nested Events
-  Nest ScriptableObjects (and other type of project assets) manually by pressing ALT and dragging the asset onto another asset 
    in the project view.
 
Video 1: https://www.youtube.com/watch?v=6KaW-NeFDTg 

Video 2: https://user-images.githubusercontent.com/68739517/143941070-8175ed01-6bb7-48f7-a66d-3b5faf18fc7c.mp4

 