### PR TITLE
#67 [FEATURE] Set event name suggestion on Variable Changed event creation 

### DIFF
--- a/Packages/Core/Editor/Drawers/AtomDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomDrawer.cs
@@ -154,18 +154,9 @@ namespace UnityAtoms.Editor
                         drawerData.UserClickedToCreateAtom = true;
                         EditorGUI.FocusTextInControl(NAMING_FIELD_CONTROL_NAME);
 
-                        if (property.GetParent() is BaseAtom abc)
-                        {
-                            var atomName = AtomNameUtils.CheckForDuplicateAtom(abc.name + AtomNameUtils.CleanPropertyName(property.name)
-                                + AtomNameUtils.FilterLastIndexOf(typeof(T).ToString(), "."));
-                            drawerData.NameOfNewAtom = atomName;
-                        }
-                        else
-                        {
-                            var atomName = AtomNameUtils.CheckForDuplicateAtom(AtomNameUtils.CleanPropertyName(property.name)
-                                + AtomNameUtils.FilterLastIndexOf(typeof(T).ToString(), "."));
-                            drawerData.NameOfNewAtom = atomName;
-                        }
+                        var baseAtomName = AtomNameUtils.CleanPropertyName(property.name) + typeof(T).Name;
+                        var atomName = property.GetParent() is BaseAtom parentAtom ? parentAtom.name + baseAtomName : baseAtomName;
+                        drawerData.NameOfNewAtom = AtomNameUtils.CreateUniqueName(atomName);
                     }
                 }
             }

--- a/Packages/Core/Editor/Drawers/AtomDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomDrawer.cs
@@ -1,7 +1,6 @@
 #if UNITY_2018_3_OR_NEWER
 using System.Collections.Generic;
 using System.IO;
-using System.Text.RegularExpressions;
 using UnityEditor;
 using UnityEngine;
 
@@ -152,19 +151,19 @@ namespace UnityAtoms.Editor
                 {
                     if (GUI.Button(restRect, "Create"))
                     {
-                        drawerData.NameOfNewAtom = "";
                         drawerData.UserClickedToCreateAtom = true;
-
                         EditorGUI.FocusTextInControl(NAMING_FIELD_CONTROL_NAME);
 
                         if (property.GetParent() is BaseAtom abc)
                         {
-                            var atomName = CheckForDuplicateAtom(abc.name + CleanPropertyName(property.name) + CreatePrettier(typeof(T).ToString(), "."));
+                            var atomName = AtomNameUtils.CheckForDuplicateAtom(abc.name + AtomNameUtils.CleanPropertyName(property.name)
+                                + AtomNameUtils.FilterLastIndexOf(typeof(T).ToString(), "."));
                             drawerData.NameOfNewAtom = atomName;
                         }
                         else
                         {
-                            var atomName = CheckForDuplicateAtom(CleanPropertyName(property.name) + CreatePrettier(typeof(T).ToString(), "."));
+                            var atomName = AtomNameUtils.CheckForDuplicateAtom(AtomNameUtils.CleanPropertyName(property.name)
+                                + AtomNameUtils.FilterLastIndexOf(typeof(T).ToString(), "."));
                             drawerData.NameOfNewAtom = atomName;
                         }
                     }
@@ -173,39 +172,6 @@ namespace UnityAtoms.Editor
 
             EditorGUI.indentLevel = indent;
             EditorGUI.EndProperty();
-        }
-
-        private string CreatePrettier(string result, string identifier)
-        {
-            return result.Contains(identifier) ? result[(result.LastIndexOf(identifier) + 1)..] : result;
-        }
-
-        private string CleanPropertyName(string propertyName)
-        {
-            var cleanString = propertyName;
-            if (propertyName[0].ToString() == "_")
-            {
-                cleanString = propertyName[1..];
-            }
-            if (Regex.Match(cleanString, @"[a-zA-Z]").Success)
-            {
-                var index = Regex.Match(cleanString, @"[a-zA-Z]").Index;
-                cleanString = cleanString[index].ToString().ToUpper() + cleanString[(index + 1)..];
-            }
-            return cleanString;
-        }
-
-        private string CheckForDuplicateAtom(string atomName)
-        {
-            var results = AssetDatabase.FindAssets(atomName);
-            if (results.Length > 0)
-            {
-                return atomName + " (" + results.Length.ToString() + ")";
-            }
-            else
-            {
-                return atomName;
-            }
         }
     }
 }

--- a/Packages/Core/Editor/Utils/AtomNameUtils.cs
+++ b/Packages/Core/Editor/Utils/AtomNameUtils.cs
@@ -1,0 +1,42 @@
+using System.Text.RegularExpressions;
+using UnityEditor;
+
+namespace UnityAtoms.Editor
+{
+    public static class AtomNameUtils
+    {
+        public static string FilterLastIndexOf(string result, string identifier)
+        {
+            return result.Contains(identifier) ? result[(result.LastIndexOf(identifier) + 1)..] : result;
+        }
+
+        public static string CleanPropertyName(string propertyName)
+        {
+            string cleanedProperty = propertyName;
+            if (propertyName[0].ToString() == "_")
+            {
+                cleanedProperty = propertyName[1..];
+            }
+            if (Regex.Match(cleanedProperty, @"[a-zA-Z]").Success)
+            {
+                var index = Regex.Match(cleanedProperty, @"[a-zA-Z]").Index;
+                cleanedProperty = cleanedProperty[index].ToString().ToUpper() + cleanedProperty[(index + 1)..];
+            }
+            return cleanedProperty;
+        }
+
+        public static string CheckForDuplicateAtom(string atomName)
+        {
+            var results = AssetDatabase.FindAssets(atomName);
+            if (results.Length > 0)
+            {
+                return $"{atomName} ({results.Length})";
+            }
+            else
+            {
+                return atomName;
+            }
+        }
+    }
+}
+

--- a/Packages/Core/Editor/Utils/AtomNameUtils.cs
+++ b/Packages/Core/Editor/Utils/AtomNameUtils.cs
@@ -7,7 +7,7 @@ namespace UnityAtoms.Editor
     {
         public static string FilterLastIndexOf(string result, string identifier)
         {
-            return result.Contains(identifier) ? result[(result.LastIndexOf(identifier) + 1)..] : result;
+            return result.Contains(identifier) ? result.Substring(result.LastIndexOf(identifier) + 1) : result;
         }
 
         public static string CleanPropertyName(string propertyName)
@@ -15,12 +15,12 @@ namespace UnityAtoms.Editor
             string cleanedProperty = propertyName;
             if (propertyName[0].ToString() == "_")
             {
-                cleanedProperty = propertyName[1..];
+                cleanedProperty = propertyName.Substring(1);
             }
             if (Regex.Match(cleanedProperty, @"[a-zA-Z]").Success)
             {
                 var index = Regex.Match(cleanedProperty, @"[a-zA-Z]").Index;
-                cleanedProperty = cleanedProperty[index].ToString().ToUpper() + cleanedProperty[(index + 1)..];
+                cleanedProperty = cleanedProperty[index].ToString().ToUpper() + cleanedProperty.Substring(index + 1);
             }
             return cleanedProperty;
         }
@@ -28,14 +28,7 @@ namespace UnityAtoms.Editor
         public static string CheckForDuplicateAtom(string atomName)
         {
             var results = AssetDatabase.FindAssets(atomName);
-            if (results.Length > 0)
-            {
-                return $"{atomName} ({results.Length})";
-            }
-            else
-            {
-                return atomName;
-            }
+            return results.Length > 0 ? $"{atomName} ({results.Length})" : atomName;
         }
     }
 }

--- a/Packages/Core/Editor/Utils/AtomNameUtils.cs
+++ b/Packages/Core/Editor/Utils/AtomNameUtils.cs
@@ -5,18 +5,9 @@ namespace UnityAtoms.Editor
 {
     public static class AtomNameUtils
     {
-        public static string FilterLastIndexOf(string result, string identifier)
-        {
-            return result.Contains(identifier) ? result.Substring(result.LastIndexOf(identifier) + 1) : result;
-        }
-
         public static string CleanPropertyName(string propertyName)
         {
             string cleanedProperty = propertyName;
-            if (propertyName[0].ToString() == "_")
-            {
-                cleanedProperty = propertyName.Substring(1);
-            }
             if (Regex.Match(cleanedProperty, @"[a-zA-Z]").Success)
             {
                 var index = Regex.Match(cleanedProperty, @"[a-zA-Z]").Index;
@@ -25,7 +16,7 @@ namespace UnityAtoms.Editor
             return cleanedProperty;
         }
 
-        public static string CheckForDuplicateAtom(string atomName)
+        public static string CreateUniqueName(string atomName)
         {
             var results = AssetDatabase.FindAssets(atomName);
             return results.Length > 0 ? $"{atomName} ({results.Length})" : atomName;

--- a/Packages/Core/Editor/Utils/AtomNameUtils.cs.meta
+++ b/Packages/Core/Editor/Utils/AtomNameUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1ff1110ec6aeba04e91c0f91cd32d49c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
https://youtu.be/_seSt3tMZdU 

Currently the implementation suggests a name for a new Event or variable when created with the 'Create' button. If the parent of the property is a BaseAtom (Variable, valuelist, FSM etc) the naming structure is: "name of variable/valuelist/FSM" + name of property ("Changed" when you add a variable changed event) + type of Event/variable ("BoolEvent" for example). When you try to create a second default named event the system will add a number at the end just like it is with duplicating GameObjects. Everything can be seen in the video above. 

There are some occasions where this default naming scheme can be a bit weird, as you can see with SetIntVariableValue as an example. However if you create custom names for a variable things get quite clear. If there are suggestions for a better naming scheme I will be happy too change things where needed.
