### PR TITLE
#194 [FEATURE] Replay Buffer Settings 

### DIFF
--- a/Packages/Core/Runtime/Events/AtomEvent.cs
+++ b/Packages/Core/Runtime/Events/AtomEvent.cs
@@ -25,6 +25,9 @@ namespace UnityAtoms
         [SerializeField]
         protected event Action<T> _onEvent;
 
+        [SerializeField]
+        private bool _useLocalReplayBuffer = true;
+
         /// <summary>
         /// The event replays the specified number of old values to new subscribers. Works like a ReplaySubject in Rx.
         /// </summary>
@@ -34,6 +37,14 @@ namespace UnityAtoms
         private int _replayBufferSize = 1;
 
         private Queue<T> _replayBuffer = new Queue<T>();
+
+        private void OnEnable()
+        {
+            if (!_useLocalReplayBuffer)
+            {
+                _replayBufferSize = AtomPreferences.ReplayBufferSize;
+            }
+        }
 
         private void OnDisable()
         {

--- a/Packages/Core/Runtime/Events/AtomEvent.cs
+++ b/Packages/Core/Runtime/Events/AtomEvent.cs
@@ -26,7 +26,7 @@ namespace UnityAtoms
         protected event Action<T> _onEvent;
 
         [SerializeField]
-        private bool _useLocalReplayBuffer = true;
+        private bool _useLocalReplayBuffer = false;
 
         /// <summary>
         /// The event replays the specified number of old values to new subscribers. Works like a ReplaySubject in Rx.
@@ -90,10 +90,13 @@ namespace UnityAtoms
         /// Register handler to be called when the Event triggers.
         /// </summary>
         /// <param name="action">The handler.</param>
-        public void Register(Action<T> action)
+        public void Register(Action<T> action, bool replayEventsBuffer = true)
         {
             _onEvent += action;
-            ReplayBufferToSubscriber(action);
+            if (replayEventsBuffer)
+            {
+                ReplayBufferToSubscriber(action);
+            }
         }
 
         /// <summary>

--- a/Packages/Core/Runtime/Listeners/AtomBaseListener.cs
+++ b/Packages/Core/Runtime/Listeners/AtomBaseListener.cs
@@ -30,6 +30,11 @@ namespace UnityAtoms
         where UER : UnityEvent<T>
     {
         /// <summary>
+        /// The boolean to enable or disable this listeners replay event buffer.
+        /// </summary>
+        public bool ReplayEventBufferOnRegister { get { return _replayEventBufferOnRegister; } set { _replayEventBufferOnRegister = value; } }
+
+        /// <summary>
         /// The Event we are listening for as a property.
         /// </summary>
         /// <value>The Event of type `E`.</value>

--- a/Packages/Core/Runtime/Listeners/AtomBaseListener.cs
+++ b/Packages/Core/Runtime/Listeners/AtomBaseListener.cs
@@ -7,6 +7,7 @@ namespace UnityAtoms
     /// <summary>
     /// None generic base class for all Listeners.
     /// </summary>
+    [DefaultExecutionOrder(Runtime.ExecutionOrder.LISTENER_BASE)]
     public abstract class AtomBaseListener : MonoBehaviour
     {
         /// <summary>

--- a/Packages/Core/Runtime/Observables/ObservableEvent.cs
+++ b/Packages/Core/Runtime/Observables/ObservableEvent.cs
@@ -8,9 +8,9 @@ namespace UnityAtoms
         private Action<Action<T>> _unregister;
         private List<IObserver<T>> _observers = new List<IObserver<T>>();
 
-        public ObservableEvent(Action<Action<T>> register, Action<Action<T>> unregister)
+        public ObservableEvent(Action<Action<T>, bool> register, Action<Action<T>> unregister)
         {
-            register(NotifyObservers);
+            register(NotifyObservers, true);
             _unregister = unregister;
         }
 

--- a/Packages/Core/Runtime/Preferences/AtomsPreferences.cs
+++ b/Packages/Core/Runtime/Preferences/AtomsPreferences.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_EDITOR
+#if UNITY_EDITOR
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor;
@@ -40,9 +40,31 @@ namespace UnityAtoms
             }
         }
 
+        public class IntPreference : Preference<int>
+        {
+            public override int Get()
+            {
+                if (!EditorPrefs.HasKey(Key))
+                {
+                    EditorPrefs.SetInt(Key, DefaultValue);
+                }
+
+                return EditorPrefs.GetInt(Key);
+            }
+
+            public override void Set(int value)
+            {
+                EditorPrefs.SetInt(Key, value);
+            }
+        }
+
         public static bool IsDebugModeEnabled { get => DEBUG_MODE_PREF.Get(); }
 
         private static BoolPreference DEBUG_MODE_PREF = new BoolPreference() { DefaultValue = false, Key = "UnityAtoms.DebugMode" };
+
+        public static int ReplayBufferSize { get => DEFAULT_BUFFER_SIZE_PREF.Get(); }
+
+        private static IntPreference DEFAULT_BUFFER_SIZE_PREF = new IntPreference() { DefaultValue = 0, Key = "UnityAtoms.ReplayBufferSize" };
 
 #if UNITY_2019_1_OR_NEWER
         [SettingsProvider]
@@ -88,6 +110,21 @@ namespace UnityAtoms
                     };
                     enableDebug.RegisterValueChangedCallback((changeEvt) => DEBUG_MODE_PREF.Set(changeEvt.newValue));
                     wrapper.Add(enableDebug);
+
+                    var replayBufferSize = new SliderInt()
+                    {
+                        label = "Replay buffer size (1-10)",
+#if UNITY_2020_2_OR_NEWER
+                        showInputField = true,
+#endif
+                        highValue = 10,
+                        lowValue = 0,
+                        pageSize = 1,
+                        value = DEFAULT_BUFFER_SIZE_PREF.Get(),
+                        tooltip = "Set the default replay buffer size for each new created Event.",
+                    };
+                    replayBufferSize.RegisterValueChangedCallback((changeEvt) => DEFAULT_BUFFER_SIZE_PREF.Set(changeEvt.newValue));
+                    wrapper.Add(replayBufferSize);
 
                     rootElement.Add(wrapper);
                 },

--- a/Packages/Core/Runtime/Preferences/AtomsPreferences.cs
+++ b/Packages/Core/Runtime/Preferences/AtomsPreferences.cs
@@ -113,9 +113,11 @@ namespace UnityAtoms
 
                     var replayBufferSize = new SliderInt()
                     {
-                        label = "Replay buffer size (1-10)",
 #if UNITY_2020_2_OR_NEWER
+                        label = "Default replay buffer size",
                         showInputField = true,
+#else
+                        label = "Default replay buffer size (1-10)",
 #endif
                         highValue = 10,
                         lowValue = 0,

--- a/Packages/Core/Runtime/Utils/Runtime.cs
+++ b/Packages/Core/Runtime/Utils/Runtime.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 
 namespace UnityAtoms
 {
@@ -23,8 +23,10 @@ namespace UnityAtoms
         /// </summary>
         public static class ExecutionOrder
         {
-            public const int VARIABLE_RESETTER = -200;
-            public const int VARIABLE_INSTANCER = -100;
+            public const int VARIABLE_BASE = -400;
+            public const int VARIABLE_RESETTER = -300;
+            public const int VARIABLE_INSTANCER = -200;
+            public const int LISTENER_BASE = -100;
         }
 
         /// <summary>

--- a/Packages/Core/Runtime/Variables/AtomBaseVariable.cs
+++ b/Packages/Core/Runtime/Variables/AtomBaseVariable.cs
@@ -7,6 +7,7 @@ namespace UnityAtoms
     /// None generic base class for Variables. Inherits from `BaseAtom`.
     /// </summary>
     [EditorIcon("atom-icon-teal")]
+    [DefaultExecutionOrder(Runtime.ExecutionOrder.VARIABLE_BASE)]
     public abstract class AtomBaseVariable : BaseAtom
     {
         public String Id { get => _id; set => _id = value; }


### PR DESCRIPTION
Added a few things regarding the settings for replay buffers.

- Global Replay buffer default setting (Edit => preferences => Unity Atoms => Default replay buffer)
- Option to use a local replay buffer setting for an event.
- Added ReplayEventBufferOnListener property to change replay listening through code.
- Added replayEventsBuffer as parameter in Register method of Events (default is true). This way when registering through code tthe replay buffer can be ignored.
 
 Note: When testing with the infintewaves example, make sure you set _useLocalReplayBuffer to true to make sure the example scene and scriptableobjects do not get reset to the global default value.
 
 Found in class Packages/Core/Runtime/Events/AtomEvent.cs line 29.