### PR TITLE
Workflow for acquiring Unity activation file

### DIFF
--- a/.github/workflows/activation.yml
+++ b/.github/workflows/activation.yml
@@ -1,0 +1,20 @@
+name: Acquire activation file
+
+on:
+  workflow_dispatch:
+
+jobs:
+  activation:
+    name: Request manual activation file 🔑
+    runs-on: ubuntu-latest
+    steps:
+      # Request manual activation file
+      - name: Request manual activation file
+        id: getManualLicenseFile
+        uses: game-ci/unity-request-activation-file@v2
+      # Upload artifact (Unity_v20XX.X.XXXX.alf)
+      - name: Expose as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ steps.getManualLicenseFile.outputs.filePath }}
+          path: ${{ steps.getManualLicenseFile.outputs.filePath }}


### PR DESCRIPTION
This workflow needs to be executed from the master branch. It is necessary to activate a license for Unity to execute unit tests in the future.