### PR TITLE
fixing unnecessary allocations when debug mode disabled

### DIFF
--- a/Packages/Core/Runtime/StackTrace/StackTraceEntry.cs
+++ b/Packages/Core/Runtime/StackTrace/StackTraceEntry.cs
@@ -60,9 +60,9 @@ namespace UnityAtoms
             }
         }
 
-        public static StackTraceEntry Create(object obj, int skipFrames = 0) => new StackTraceEntry(new StackTrace(skipFrames), obj);
+        public static StackTraceEntry Create(object obj, int skipFrames = 0) => AtomPreferences.IsDebugModeEnabled ? new StackTraceEntry(new StackTrace(skipFrames), obj) : null;
 
-        public static StackTraceEntry Create(int skipFrames = 0) => new StackTraceEntry(new StackTrace(skipFrames));
+        public static StackTraceEntry Create(int skipFrames = 0) => AtomPreferences.IsDebugModeEnabled ? new StackTraceEntry(new StackTrace(skipFrames)) : null;
 
 
         public override bool Equals(object obj) => Equals(obj as StackTraceEntry);


### PR DESCRIPTION
fixes the issue: 
https://github.com/unity-atoms/unity-atoms/issues/328

another option for the fix would be to return an Action/Func which then only creates a StackEntry in https://github.com/unity-atoms/unity-atoms/blob/85bbaa03bb29b16776d631c033d8b514a32472b3/Packages/Core/Runtime/StackTrace/StackTraces.cs#L12 if needed. 

but this would actually change the method heads of public methods and thus would be a breaking change, requiring a major version upgrade.

thus this simple fix of returning null 

( also, the Action or Func object itself would also allocate memory, this could be circumvented with a custom `ref struct Func`, .... but at this point it would be totally overengineered)