### PR TITLE
Remove Casey-Hofland from list of maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,5 @@ For questions and support please join our [Discord channel](https://discord.gg/W
 -   [AdamRamberg](https://github.com/AdamRamberg)
 -   [soraphis](https://github.com/soraphis)
 -   [miikalo](https://github.com/miikalo)
--   [Casey-Hofland](https://github.com/Casey-Hofland)
 
 We are looking for more people to join the team! Contact us if you want to jump aboard.


### PR DESCRIPTION
Unfortunately Casey-Hofland was unable to continue as a maintainer. This PR updates the README.md to reflect that.