### PR TITLE
Fix #321 NRE when Event Reference Listeners event reference is not set

### DIFF
--- a/Packages/Core/Runtime/EventReferences/AtomEventReference.cs
+++ b/Packages/Core/Runtime/EventReferences/AtomEventReference.cs
@@ -27,12 +27,9 @@ namespace UnityAtoms
             {
                 switch (_usage)
                 {
-                    case (AtomEventReferenceUsage.VARIABLE):
-                        return _variable == null ? LogNullReference(nameof(_variable)) : _variable.GetOrCreateEvent<E>();
-                    case (AtomEventReferenceUsage.VARIABLE_INSTANCER):
-                        return _variableInstancer == null ? LogNullReference(nameof(_variableInstancer)) : _variableInstancer.GetOrCreateEvent<E>();
-                    case (AtomEventReferenceUsage.EVENT_INSTANCER):
-                        return _eventInstancer == null ? LogNullReference(nameof(_eventInstancer)) : _eventInstancer.Event;
+                    case (AtomEventReferenceUsage.VARIABLE): return _variable == null ? null : _variable.GetOrCreateEvent<E>();
+                    case (AtomEventReferenceUsage.VARIABLE_INSTANCER): return _variableInstancer == null ? null : _variableInstancer.GetOrCreateEvent<E>();
+                    case (AtomEventReferenceUsage.EVENT_INSTANCER): return _eventInstancer == null ? null : _eventInstancer.Event;
                     case (AtomEventReferenceUsage.EVENT):
                     default:
                         return _event;
@@ -83,19 +80,6 @@ namespace UnityAtoms
         public static implicit operator E(AtomEventReference<T, V, E, VI, EI> reference)
         {
             return reference.Event;
-        }
-
-        private E LogNullReference(string atomEventReferenceUsage)
-        {
-            if (AtomPreferences.IsDebugModeEnabled)
-            {
-                Debug.Log($"{atomEventReferenceUsage} reference is missing in inspector.");
-                return null;
-            }
-            else
-            {
-                return null;
-            }
         }
     }
 }

--- a/Packages/Core/Runtime/EventReferences/AtomEventReference.cs
+++ b/Packages/Core/Runtime/EventReferences/AtomEventReference.cs
@@ -27,9 +27,12 @@ namespace UnityAtoms
             {
                 switch (_usage)
                 {
-                    case (AtomEventReferenceUsage.VARIABLE): return _variable.GetOrCreateEvent<E>();
-                    case (AtomEventReferenceUsage.VARIABLE_INSTANCER): return _variableInstancer.GetOrCreateEvent<E>();
-                    case (AtomEventReferenceUsage.EVENT_INSTANCER): return _eventInstancer.Event;
+                    case (AtomEventReferenceUsage.VARIABLE):
+                        return _variable == null ? LogNullReference(nameof(_variable)) : _variable.GetOrCreateEvent<E>();
+                    case (AtomEventReferenceUsage.VARIABLE_INSTANCER):
+                        return _variableInstancer == null ? LogNullReference(nameof(_variableInstancer)) : _variableInstancer.GetOrCreateEvent<E>();
+                    case (AtomEventReferenceUsage.EVENT_INSTANCER):
+                        return _eventInstancer == null ? LogNullReference(nameof(_eventInstancer)) : _eventInstancer.Event;
                     case (AtomEventReferenceUsage.EVENT):
                     default:
                         return _event;
@@ -80,6 +83,18 @@ namespace UnityAtoms
         public static implicit operator E(AtomEventReference<T, V, E, VI, EI> reference)
         {
             return reference.Event;
+        }
+
+        private E LogNullReference(string atomEventReferenceUsage)
+        {
+            if (AtomPreferences.IsDebugModeEnabled)
+            {
+                throw new NullReferenceException($"{atomEventReferenceUsage} reference is missing in inspector.");
+            }
+            else
+            {
+                return null;
+            }
         }
     }
 }

--- a/Packages/Core/Runtime/EventReferences/AtomEventReference.cs
+++ b/Packages/Core/Runtime/EventReferences/AtomEventReference.cs
@@ -89,7 +89,8 @@ namespace UnityAtoms
         {
             if (AtomPreferences.IsDebugModeEnabled)
             {
-                throw new NullReferenceException($"{atomEventReferenceUsage} reference is missing in inspector.");
+                Debug.Log($"{atomEventReferenceUsage} reference is missing in inspector.");
+                return null;
             }
             else
             {


### PR DESCRIPTION
As suggested by @soraphis changed that the Event reference listener doesn't just throw a null reference exception everywhere. I added a check for Atoms debug mode. In debug mode the user gets notified of the null reference which he has. But in runtime/production this exception doesn't get thrown.

I chose for a NRE because on clicking this error the connected gameObject gets pinged. This doesn't happen when using the Unity Debug class.