### PR TITLE
Atom drawer rewrite

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -1,0 +1,6 @@
+﻿{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Workload.ManagedGame"
+  ]
+}

--- a/Packages/BaseAtoms/Runtime/Collections/AtomBaseVariableList.cs
+++ b/Packages/BaseAtoms/Runtime/Collections/AtomBaseVariableList.cs
@@ -29,7 +29,7 @@ namespace UnityAtoms.BaseAtoms
         private event Action<AtomBaseVariable> _removed;
         private event Action _cleared;
 
-        [SerializeField, HideCreate]
+        [SerializeField, ObjectFieldSubType(typeof(AtomBaseVariable)), HideCreate]
         private List<AtomBaseVariable> _serializedList = new List<AtomBaseVariable>();
 
         public void OnAfterDeserialize()

--- a/Packages/BaseAtoms/Runtime/Collections/AtomBaseVariableList.cs
+++ b/Packages/BaseAtoms/Runtime/Collections/AtomBaseVariableList.cs
@@ -29,7 +29,7 @@ namespace UnityAtoms.BaseAtoms
         private event Action<AtomBaseVariable> _removed;
         private event Action _cleared;
 
-        [SerializeField]
+        [SerializeField, HideCreate]
         private List<AtomBaseVariable> _serializedList = new List<AtomBaseVariable>();
 
         public void OnAfterDeserialize()

--- a/Packages/BaseAtoms/Runtime/Collections/SerializableDictionary.cs
+++ b/Packages/BaseAtoms/Runtime/Collections/SerializableDictionary.cs
@@ -26,7 +26,7 @@ namespace UnityAtoms.BaseAtoms
 
         [SerializeField]
         private List<K> _serializedKeys = new List<K>();
-        [SerializeField, HideCreate]
+        [SerializeField,ObjectFieldSubType(typeof(AtomBaseVariable)), HideCreate]
         private List<V> _serializedValues = new List<V>();
 
         /// <summary>

--- a/Packages/BaseAtoms/Runtime/Collections/SerializableDictionary.cs
+++ b/Packages/BaseAtoms/Runtime/Collections/SerializableDictionary.cs
@@ -26,7 +26,7 @@ namespace UnityAtoms.BaseAtoms
 
         [SerializeField]
         private List<K> _serializedKeys = new List<K>();
-        [SerializeField]
+        [SerializeField, HideCreate]
         private List<V> _serializedValues = new List<V>();
 
         /// <summary>

--- a/Packages/Core/Editor/Drawers/AtomDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomDrawer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
@@ -12,7 +13,42 @@ namespace UnityAtoms.Editor
     [CustomPropertyDrawer(typeof(BaseAtom), true)]
     public class AtomDrawer : PropertyDrawer
     {
+        class DrawerData
+        {
+            public bool UserClickedToCreateAtom = false;
+            public string NameOfNewAtom = "";
+            public string WarningText = "";
+            public Type fieldType;
+        }
+
+        private const string NAMING_FIELD_CONTROL_NAME = "Naming Field";
+
+        private Dictionary<string, DrawerData> _perPropertyViewData = new Dictionary<string, DrawerData>();
         private static Dictionary<string, int> _perPropertyObjectPickerID = new Dictionary<string, int>();
+
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            if (property.serializedObject.isEditingMultipleObjects)
+            {
+                return EditorGUI.GetPropertyHeight(property);
+            }
+
+            DrawerData drawerData = GetDrawerData(property.propertyPath);
+            var isCreatingSO = drawerData.UserClickedToCreateAtom && property.objectReferenceValue == null;
+            if (!isCreatingSO || drawerData.WarningText.Length <= 0) return base.GetPropertyHeight(property, label);
+            return base.GetPropertyHeight(property, label) * 2 + 4f;
+        }
+
+        private DrawerData GetDrawerData(string propertyPath)
+        {
+            DrawerData drawerData;
+            if (!_perPropertyViewData.TryGetValue(propertyPath, out drawerData))
+            {
+                drawerData = new DrawerData();
+                _perPropertyViewData[propertyPath] = drawerData;
+            }
+            return drawerData;
+        }
 
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
@@ -24,84 +60,132 @@ namespace UnityAtoms.Editor
 
             EditorGUI.BeginProperty(position, label, property);
 
+            DrawerData drawerData = GetDrawerData(property.propertyPath);
+
+            var isCreatingSO = drawerData.UserClickedToCreateAtom && property.objectReferenceValue == null;
+            var restWidth = drawerData.UserClickedToCreateAtom ? 50 : 58;
+            var gutter = drawerData.UserClickedToCreateAtom ? 2f : 6f;
             Rect restRect = new Rect();
+            Rect warningRect = new Rect();
+
+            if (drawerData.WarningText.Length > 0)
+            {
+                position = IMGUIUtils.SnipRectV(position, EditorGUIUtility.singleLineHeight, out warningRect, 2f);
+            }
 
             if (property.objectReferenceValue == null)
             {
-                position = IMGUIUtils.SnipRectH(position, position.width - 58f, out restRect, 6f);
+                position = IMGUIUtils.SnipRectH(position, position.width - restWidth, out restRect, gutter);
             }
+
+            var defaultGUIColor = GUI.color;
+            GUI.color = isCreatingSO ? Color.yellow : defaultGUIColor;
+            position = EditorGUI.PrefixLabel(position, GUIUtility.GetControlID(FocusType.Passive), isCreatingSO && label != GUIContent.none ? new GUIContent("Name of New Atom") : label);
+            GUI.color = defaultGUIColor;
 
             var indent = EditorGUI.indentLevel;
             EditorGUI.indentLevel = 0;
 
-            if(fieldInfo.FieldType.IsGenericType)
+            GUI.SetNextControlName(NAMING_FIELD_CONTROL_NAME);
+            drawerData.NameOfNewAtom = EditorGUI.TextField(isCreatingSO ? position : Rect.zero, drawerData.NameOfNewAtom);
+
+            if (!isCreatingSO)
             {
-                int controlID;
-
-                var objectPickerButtonRect = new Rect(position);
-                objectPickerButtonRect.x += objectPickerButtonRect.width - 20f;
-                objectPickerButtonRect.width = 20f;
-
-                if(GUI.Button(objectPickerButtonRect, string.Empty, GUIStyle.none))
+                if (fieldInfo.FieldType.IsGenericType)
                 {
-                    var types = GetInstantiateableChildrenTypes();
-                    var filter = string.Join(" ", types.Select(type => $"t:{type.Name}"));
+                    int controlID;
 
-                    controlID = GUIUtility.GetControlID(FocusType.Keyboard);
-                    EditorGUIUtility.ShowObjectPicker<MonoBehaviour>(property.objectReferenceValue, false, filter, controlID);
+                    var objectPickerButtonRect = new Rect(position);
+                    objectPickerButtonRect.x += objectPickerButtonRect.width - 20f;
+                    objectPickerButtonRect.width = 20f;
 
-                    _perPropertyObjectPickerID[property.propertyPath] = controlID;
+                    drawerData.fieldType = GetAtomEventType();
+
+                    if (GUI.Button(objectPickerButtonRect, string.Empty, GUIStyle.none))
+                    {
+                        var types = GetInstantiateableChildrenTypes();
+                        var filter = string.Join(" ", types.Select(type => $"t:{type.Name}"));
+                        
+                        controlID = GUIUtility.GetControlID(FocusType.Keyboard);
+                        EditorGUIUtility.ShowObjectPicker<MonoBehaviour>(property.objectReferenceValue, false, filter, controlID);
+
+                        _perPropertyObjectPickerID[property.propertyPath] = controlID;
+                    }
+
+                    if (_perPropertyObjectPickerID.TryGetValue(property.propertyPath, out controlID)
+                        && controlID == EditorGUIUtility.GetObjectPickerControlID())
+                    {
+                        property.objectReferenceValue = EditorGUIUtility.GetObjectPickerObject();
+                    }
                 }
-
-                if(_perPropertyObjectPickerID.TryGetValue(property.propertyPath, out controlID)
-                    && controlID == EditorGUIUtility.GetObjectPickerControlID())
+               
+                EditorGUI.BeginChangeCheck();
+                var obj = EditorGUI.ObjectField(position, property.objectReferenceValue, drawerData.fieldType, false);
+                if (EditorGUI.EndChangeCheck())
                 {
-                    property.objectReferenceValue = EditorGUIUtility.GetObjectPickerObject();
+                    property.objectReferenceValue = obj;
                 }
             }
 
-            property.objectReferenceValue = EditorGUI.ObjectField(position, property.objectReferenceValue, fieldInfo.FieldType, false);
-
             if (property.objectReferenceValue == null)
             {
-                if(GUI.Button(restRect, "Create"))
+                if (isCreatingSO)
                 {
-                    var types = GetInstantiateableChildrenTypes();
-
-                    switch(types.Length)
+                    var buttonWidth = 24;
+                    Rect secondButtonRect;
+                    Rect firstButtonRect = IMGUIUtils.SnipRectH(restRect, restRect.width - buttonWidth, out secondButtonRect, gutter);
+                    if (GUI.Button(firstButtonRect, "✓")
+                        || (Event.current.keyCode == KeyCode.Return
+                            && GUI.GetNameOfFocusedControl() == NAMING_FIELD_CONTROL_NAME))
                     {
-                        case 0:
-                            break;
-                        case 1:
-                            CreateAtom(types[0]);
-                            break;
-                        default:
-                            var menu = new GenericMenu();
-                            foreach (var type in types)
+                        if (drawerData.NameOfNewAtom.Length > 0)
+                        {
+                            try
                             {
-                                menu.AddItem(new GUIContent(type.Name), false, (data) => CreateAtom((Type)data), type);
+                                string path = AssetDatabase.GetAssetPath(property.serializedObject.targetObject);
+                                path = path == "" ? "Assets/" : Path.GetDirectoryName(path) + "/";
+                                // Create asset
+                                BaseAtom so = ScriptableObject.CreateInstance<BaseAtom>();
+                                AssetDatabase.CreateAsset(so, path + drawerData.NameOfNewAtom + ".asset");
+                                AssetDatabase.SaveAssets();
+                                // Assign the newly created SO
+                                property.objectReferenceValue = so;
+                            }
+                            catch
+                            {
+                                Debug.LogError("Not able to create Atom");
                             }
 
-                            menu.DropDown(restRect);
-                            break;
+                            drawerData.UserClickedToCreateAtom = false;
+                            drawerData.WarningText = "";
+                        }
+                        else
+                        {
+                            drawerData.WarningText = "Name of new Atom must be specified!";
+                            EditorGUI.FocusTextInControl(NAMING_FIELD_CONTROL_NAME);
+                        }
+                    }
+                    if (GUI.Button(secondButtonRect, "✗")
+                        || (Event.current.keyCode == KeyCode.Escape
+                            && GUI.GetNameOfFocusedControl() == NAMING_FIELD_CONTROL_NAME))
+                    {
+                        drawerData.UserClickedToCreateAtom = false;
+                        drawerData.WarningText = "";
                     }
 
-                    void CreateAtom(Type type)
+                    if (drawerData.WarningText.Length > 0)
                     {
-                        var path = EditorUtility.SaveFilePanelInProject("Choose Atom Location", type.Name, "asset", "Choose a location to store the Atom.");
-                        if (!string.IsNullOrEmpty(path))
-                        {
-                            path = AssetDatabase.GenerateUniqueAssetPath(path);
+                        EditorGUI.HelpBox(warningRect, drawerData.WarningText, MessageType.Warning);
+                    }
+                }
+                else
+                {
+                    if (GUI.Button(restRect, "Create"))
+                    {
+                        drawerData.NameOfNewAtom = "";
+                        drawerData.UserClickedToCreateAtom = true;
 
-                            // Create Asset
-                            var so = ScriptableObject.CreateInstance(type);
-
-                            AssetDatabase.CreateAsset(so, path);
-                            AssetDatabase.SaveAssets();
-
-                            // Assign the newly created so
-                            property.objectReferenceValue = so;
-                        }
+                        EditorGUI.FocusTextInControl(NAMING_FIELD_CONTROL_NAME);
                     }
                 }
             }
@@ -112,12 +196,12 @@ namespace UnityAtoms.Editor
 
         private Type[] GetInstantiateableChildrenTypes()
         {
-            return (from assembly in AppDomain.CurrentDomain.GetAssemblies()
-                    from type in assembly.GetTypes()
-                    where !type.IsAbstract
-                    where !type.IsGenericType
-                    where type == fieldInfo.FieldType || type.IsSubclassOf(fieldInfo.FieldType)
-                    select type).ToArray();
+            return TypeCache.GetTypesDerivedFrom(fieldInfo.FieldType).ToArray();
+        }
+
+        private Type GetAtomEventType()
+        {
+            return TypeCache.GetTypesDerivedFrom(fieldInfo.FieldType).First();
         }
     }
 }

--- a/Packages/Core/Editor/Drawers/AtomDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomDrawer.cs
@@ -77,7 +77,7 @@ namespace UnityAtoms.Editor
             {
                 position = IMGUIUtils.SnipRectH(position, position.width - restWidth, out restRect, gutter);
             }
-            else if (property.GetParent() is BaseAtom ab && AtomFuser.IsValidFuse(ab))
+            else if (property.GetTopParent() is BaseAtom ab && AtomFuser.IsValidFuse(ab))
             {
                 position = IMGUIUtils.SnipRectH(position, position.width - restWidth, out fuseRect, gutter);
             }
@@ -95,37 +95,11 @@ namespace UnityAtoms.Editor
 
             if (!isCreatingSO)
             {
-                //if (fieldInfo.FieldType.IsGenericType)
-                //{
-                //    int controlID;
-
-                //    var objectPickerButtonRect = new Rect(position);
-                //    objectPickerButtonRect.x += objectPickerButtonRect.width - 20f;
-                //    objectPickerButtonRect.width = 20f;
-
-                //    if (GUI.Button(objectPickerButtonRect, string.Empty, GUIStyle.none))
-                //    {
-                //        var types = GetInstantiateableChildrenTypes();
-                //        var filter = string.Join(" ", types.Select(type => $"t:{type.Name}"));
-                        
-                //        controlID = GUIUtility.GetControlID(FocusType.Keyboard);
-                //        EditorGUIUtility.ShowObjectPicker<MonoBehaviour>(property.objectReferenceValue, false, filter, controlID);
-
-                //        _perPropertyObjectPickerID[property.propertyPath] = controlID;
-                //    }
-
-                //    if (_perPropertyObjectPickerID.TryGetValue(property.propertyPath, out controlID)
-                //        && controlID == EditorGUIUtility.GetObjectPickerControlID())
-                //    {
-                //        property.objectReferenceValue = EditorGUIUtility.GetObjectPickerObject();
-                //    }
-                //}
-
                 EditorGUI.BeginChangeCheck();
                 var obj = EditorGUI.ObjectField(position, property.objectReferenceValue, GetAtomEventType(), false);
                 if (EditorGUI.EndChangeCheck())
                 {
-                    if (property.GetParent() is BaseAtom ab)
+                    if (property.GetTopParent() is BaseAtom ab)
                     {
                         if (obj == null && AtomFuser.IsFused(property, ab))
                         {
@@ -164,7 +138,7 @@ namespace UnityAtoms.Editor
                                 path = path == "" ? "Assets/" : Path.GetDirectoryName(path) + "/";
                                 // Create asset
                                 var so = ScriptableObject.CreateInstance(GetAtomEventType());
-                                if (property.GetParent() is BaseAtom ab)
+                                if (property.GetTopParent() is BaseAtom ab)
                                 {
                                     so.name = drawerData.NameOfNewAtom;
                                     AssetDatabase.AddObjectToAsset(so, ab);
@@ -220,7 +194,7 @@ namespace UnityAtoms.Editor
             }
             else
             {
-                if (property.GetParent() is BaseAtom ab)
+                if (property.GetTopParent() is BaseAtom ab)
                 {
                     var subAsset = AtomFuser.FindSubAsset(ab, property.objectReferenceValue);
                     if (subAsset == null)
@@ -245,7 +219,7 @@ namespace UnityAtoms.Editor
 
         private void CreateAtomName(SerializedProperty property, DrawerData drawerData)
         {
-            if (property.GetParent() is BaseAtom atom)
+            if (property.GetTopParent() is BaseAtom atom)
             {
                 var atomName = AtomNameUtils.CheckForDuplicateAtom(atom.name + AtomNameUtils.CleanPropertyName(property.name)
                     + AtomNameUtils.FilterLastIndexOf(GetAtomEventType().ToString(), "."));
@@ -258,11 +232,6 @@ namespace UnityAtoms.Editor
                 drawerData.NameOfNewAtom = atomName;
             }
         }
-
-        //private Type[] GetInstantiateableChildrenTypes()
-        //{
-        //    return TypeCache.GetTypesDerivedFrom(fieldInfo.FieldType).ToArray();
-        //}
 
         private Type GetAtomEventType()
         {

--- a/Packages/Core/Editor/Drawers/AtomDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomDrawer.cs
@@ -95,31 +95,31 @@ namespace UnityAtoms.Editor
 
             if (!isCreatingSO)
             {
-                if (fieldInfo.FieldType.IsGenericType)
-                {
-                    int controlID;
+                //if (fieldInfo.FieldType.IsGenericType)
+                //{
+                //    int controlID;
 
-                    var objectPickerButtonRect = new Rect(position);
-                    objectPickerButtonRect.x += objectPickerButtonRect.width - 20f;
-                    objectPickerButtonRect.width = 20f;
+                //    var objectPickerButtonRect = new Rect(position);
+                //    objectPickerButtonRect.x += objectPickerButtonRect.width - 20f;
+                //    objectPickerButtonRect.width = 20f;
 
-                    if (GUI.Button(objectPickerButtonRect, string.Empty, GUIStyle.none))
-                    {
-                        var types = GetInstantiateableChildrenTypes();
-                        var filter = string.Join(" ", types.Select(type => $"t:{type.Name}"));
+                //    if (GUI.Button(objectPickerButtonRect, string.Empty, GUIStyle.none))
+                //    {
+                //        var types = GetInstantiateableChildrenTypes();
+                //        var filter = string.Join(" ", types.Select(type => $"t:{type.Name}"));
                         
-                        controlID = GUIUtility.GetControlID(FocusType.Keyboard);
-                        EditorGUIUtility.ShowObjectPicker<MonoBehaviour>(property.objectReferenceValue, false, filter, controlID);
+                //        controlID = GUIUtility.GetControlID(FocusType.Keyboard);
+                //        EditorGUIUtility.ShowObjectPicker<MonoBehaviour>(property.objectReferenceValue, false, filter, controlID);
 
-                        _perPropertyObjectPickerID[property.propertyPath] = controlID;
-                    }
+                //        _perPropertyObjectPickerID[property.propertyPath] = controlID;
+                //    }
 
-                    if (_perPropertyObjectPickerID.TryGetValue(property.propertyPath, out controlID)
-                        && controlID == EditorGUIUtility.GetObjectPickerControlID())
-                    {
-                        property.objectReferenceValue = EditorGUIUtility.GetObjectPickerObject();
-                    }
-                }
+                //    if (_perPropertyObjectPickerID.TryGetValue(property.propertyPath, out controlID)
+                //        && controlID == EditorGUIUtility.GetObjectPickerControlID())
+                //    {
+                //        property.objectReferenceValue = EditorGUIUtility.GetObjectPickerObject();
+                //    }
+                //}
 
                 EditorGUI.BeginChangeCheck();
                 var obj = EditorGUI.ObjectField(position, property.objectReferenceValue, GetAtomEventType(), false);
@@ -259,10 +259,10 @@ namespace UnityAtoms.Editor
             }
         }
 
-        private Type[] GetInstantiateableChildrenTypes()
-        {
-            return TypeCache.GetTypesDerivedFrom(fieldInfo.FieldType).ToArray();
-        }
+        //private Type[] GetInstantiateableChildrenTypes()
+        //{
+        //    return TypeCache.GetTypesDerivedFrom(fieldInfo.FieldType).ToArray();
+        //}
 
         private Type GetAtomEventType()
         {

--- a/Packages/Core/Editor/Drawers/AtomDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomDrawer.cs
@@ -266,7 +266,14 @@ namespace UnityAtoms.Editor
 
         private Type GetAtomEventType()
         {
-            return TypeCache.GetTypesDerivedFrom(fieldInfo.FieldType).First();
+            if (TypeCache.GetTypesDerivedFrom(fieldInfo.FieldType).Count != 0)
+            {
+                return TypeCache.GetTypesDerivedFrom(fieldInfo.FieldType).First();
+            }
+            else
+            {
+                return TypeCache.GetTypesDerivedFrom(fieldInfo.FieldType.BaseType).First();
+            }
         }
     }
 }

--- a/Packages/Core/Editor/Drawers/AtomDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomDrawer.cs
@@ -23,7 +23,6 @@ namespace UnityAtoms.Editor
         private const string NAMING_FIELD_CONTROL_NAME = "Naming Field";
 
         private Dictionary<string, DrawerData> _perPropertyViewData = new Dictionary<string, DrawerData>();
-        private static Dictionary<string, int> _perPropertyObjectPickerID = new Dictionary<string, int>();
 
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
         {

--- a/Packages/Core/Editor/Drawers/AtomDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomDrawer.cs
@@ -18,7 +18,6 @@ namespace UnityAtoms.Editor
             public bool UserClickedToCreateAtom = false;
             public string NameOfNewAtom = "";
             public string WarningText = "";
-            public Type fieldType;
         }
 
         private const string NAMING_FIELD_CONTROL_NAME = "Naming Field";
@@ -99,8 +98,6 @@ namespace UnityAtoms.Editor
                     objectPickerButtonRect.x += objectPickerButtonRect.width - 20f;
                     objectPickerButtonRect.width = 20f;
 
-                    drawerData.fieldType = GetAtomEventType();
-
                     if (GUI.Button(objectPickerButtonRect, string.Empty, GUIStyle.none))
                     {
                         var types = GetInstantiateableChildrenTypes();
@@ -118,13 +115,8 @@ namespace UnityAtoms.Editor
                         property.objectReferenceValue = EditorGUIUtility.GetObjectPickerObject();
                     }
                 }
-               
-                EditorGUI.BeginChangeCheck();
-                var obj = EditorGUI.ObjectField(position, property.objectReferenceValue, drawerData.fieldType, false);
-                if (EditorGUI.EndChangeCheck())
-                {
-                    property.objectReferenceValue = obj;
-                }
+
+                property.objectReferenceValue = EditorGUI.ObjectField(position, property.objectReferenceValue, GetAtomEventType(), false);
             }
 
             if (property.objectReferenceValue == null)
@@ -182,16 +174,32 @@ namespace UnityAtoms.Editor
                 {
                     if (GUI.Button(restRect, "Create"))
                     {
-                        drawerData.NameOfNewAtom = "";
                         drawerData.UserClickedToCreateAtom = true;
 
                         EditorGUI.FocusTextInControl(NAMING_FIELD_CONTROL_NAME);
+                        CreateAtomName(property, drawerData);
                     }
                 }
             }
 
             EditorGUI.indentLevel = indent;
             EditorGUI.EndProperty();
+        }
+
+        private void CreateAtomName(SerializedProperty property, DrawerData drawerData)
+        {
+            if (property.GetParent() is BaseAtom atom)
+            {
+                var atomName = AtomNameUtils.CheckForDuplicateAtom(atom.name + AtomNameUtils.CleanPropertyName(property.name)
+                    + AtomNameUtils.FilterLastIndexOf(GetAtomEventType().ToString(), "."));
+                drawerData.NameOfNewAtom = atomName;
+            }
+            else
+            {
+                var atomName = AtomNameUtils.CheckForDuplicateAtom(AtomNameUtils.CleanPropertyName(property.name)
+                    + AtomNameUtils.FilterLastIndexOf(GetAtomEventType().ToString(), "."));
+                drawerData.NameOfNewAtom = atomName;
+            }
         }
 
         private Type[] GetInstantiateableChildrenTypes()

--- a/Packages/Core/Editor/Drawers/HideCreateDrawer.cs
+++ b/Packages/Core/Editor/Drawers/HideCreateDrawer.cs
@@ -5,6 +5,9 @@ using UnityEngine;
 
 namespace UnityAtoms.Editor
 {
+    /// <summary>
+    /// Property drawer to hide the ScriptableObject create button on desired fields e.g. FSM statemachine.
+    /// </summary>
     [CustomPropertyDrawer(typeof(HideCreate))]
     public class HideCreateDrawer : PropertyDrawer
     {

--- a/Packages/Core/Editor/Drawers/HideCreateDrawer.cs
+++ b/Packages/Core/Editor/Drawers/HideCreateDrawer.cs
@@ -29,7 +29,7 @@ namespace UnityAtoms.Editor
             var indent = EditorGUI.indentLevel;
             EditorGUI.indentLevel = 0;
 
-            EditorGUI.ObjectField(position, property.objectReferenceValue, GetAtomEventType(), false);
+            property.objectReferenceValue = EditorGUI.ObjectField(position, property.objectReferenceValue, GetAtomEventType(), false);
             
             EditorGUI.indentLevel = indent;
             EditorGUI.EndProperty();

--- a/Packages/Core/Editor/Drawers/HideCreateDrawer.cs
+++ b/Packages/Core/Editor/Drawers/HideCreateDrawer.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace UnityAtoms.Editor
+{
+    [CustomPropertyDrawer(typeof(HideCreate))]
+    public class HideCreateDrawer : PropertyDrawer
+    {
+        public override float GetPropertyHeight(SerializedProperty property,
+           GUIContent label)
+        {
+            return EditorGUI.GetPropertyHeight(property, label, true);
+        }
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            if (property.serializedObject.isEditingMultipleObjects)
+            {
+                EditorGUI.PropertyField(position, property, label, true);
+                return;
+            }
+
+            EditorGUI.BeginProperty(position, label, property);
+
+            position = EditorGUI.PrefixLabel(position, GUIUtility.GetControlID(FocusType.Passive), label);
+
+            var indent = EditorGUI.indentLevel;
+            EditorGUI.indentLevel = 0;
+
+            EditorGUI.ObjectField(position, property.objectReferenceValue, GetAtomEventType(), false);
+            
+            EditorGUI.indentLevel = indent;
+            EditorGUI.EndProperty();
+        }
+
+        private Type GetAtomEventType()
+        {
+            if (TypeCache.GetTypesDerivedFrom(fieldInfo.FieldType).Count != 0)
+            {
+                return TypeCache.GetTypesDerivedFrom(fieldInfo.FieldType).First();
+            }
+            else
+            {
+                return TypeCache.GetTypesDerivedFrom(fieldInfo.FieldType.BaseType).First();
+            }
+        }
+    }
+}
+

--- a/Packages/Core/Editor/Drawers/HideCreateDrawer.cs.meta
+++ b/Packages/Core/Editor/Drawers/HideCreateDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c234f2c07d830074fb4a409e31fd7876
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/Core/Editor/Drawers/ObjectFieldSubTypeDrawer.cs
+++ b/Packages/Core/Editor/Drawers/ObjectFieldSubTypeDrawer.cs
@@ -1,12 +1,11 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using UnityEditor;
 using UnityEngine;
 
 namespace UnityAtoms.Editor
 {
+    /// <summary>
+    /// Property drawer To correct certain fields into the right Type. This is used in e.g. AtomList and AtomCollection.
+    /// </summary>
     [CustomPropertyDrawer(typeof(ObjectFieldSubType))]
     public class ObjectFieldSubTypeDrawer : PropertyDrawer
     {

--- a/Packages/Core/Editor/Drawers/ObjectFieldSubTypeDrawer.cs
+++ b/Packages/Core/Editor/Drawers/ObjectFieldSubTypeDrawer.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace UnityAtoms.Editor
+{
+    [CustomPropertyDrawer(typeof(ObjectFieldSubType))]
+    public class ObjectFieldSubTypeDrawer : PropertyDrawer
+    {
+        public override float GetPropertyHeight(SerializedProperty property,
+          GUIContent label)
+        {
+            return EditorGUI.GetPropertyHeight(property, label, true);
+        }
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            ObjectFieldSubType objectFieldSubType = (ObjectFieldSubType)attribute;
+
+            if (property.serializedObject.isEditingMultipleObjects)
+            {
+                EditorGUI.PropertyField(position, property, label, true);
+                return;
+            }
+
+            EditorGUI.BeginProperty(position, label, property);
+
+            position = EditorGUI.PrefixLabel(position, GUIUtility.GetControlID(FocusType.Passive), label);
+
+            var indent = EditorGUI.indentLevel;
+            EditorGUI.indentLevel = 0;
+
+            EditorGUI.ObjectField(position, property.objectReferenceValue, objectFieldSubType.SubType, false);
+
+            EditorGUI.indentLevel = indent;
+            EditorGUI.EndProperty();
+        }
+    }
+}

--- a/Packages/Core/Editor/Drawers/ObjectFieldSubTypeDrawer.cs
+++ b/Packages/Core/Editor/Drawers/ObjectFieldSubTypeDrawer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEditor;
 using UnityEngine;
 
@@ -32,7 +33,7 @@ namespace UnityAtoms.Editor
             var indent = EditorGUI.indentLevel;
             EditorGUI.indentLevel = 0;
 
-            EditorGUI.ObjectField(position, property.objectReferenceValue, objectFieldSubType.SubType, false);
+            property.objectReferenceValue = EditorGUI.ObjectField(position, property.objectReferenceValue, objectFieldSubType.SubType, false);
 
             EditorGUI.indentLevel = indent;
             EditorGUI.EndProperty();

--- a/Packages/Core/Editor/Drawers/ObjectFieldSubTypeDrawer.cs.meta
+++ b/Packages/Core/Editor/Drawers/ObjectFieldSubTypeDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b5c78e9e678bb5641b9e5fb2aded86b2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/Core/Editor/Editors/Variables/AtomVariableEditor.cs
+++ b/Packages/Core/Editor/Editors/Variables/AtomVariableEditor.cs
@@ -81,8 +81,8 @@ namespace UnityAtoms.Editor
 
             using (new EditorGUILayout.HorizontalScope())
             {
-                EditorGUILayout.PropertyField(serializedObject.FindProperty("_changed"));
-                var changed = serializedObject.FindProperty("_changed").objectReferenceValue;
+                EditorGUILayout.PropertyField(serializedObject.FindProperty("Changed"));
+                var changed = serializedObject.FindProperty("Changed").objectReferenceValue;
                 if (changed != null && changed is AtomEventBase evt && target is AtomBaseVariable atomTarget)
                 {
                     GUILayout.Space(2);
@@ -95,8 +95,8 @@ namespace UnityAtoms.Editor
 
             using (new EditorGUILayout.HorizontalScope())
             {
-                EditorGUILayout.PropertyField(serializedObject.FindProperty("_changedWithHistory"));
-                var changedWithHistory = serializedObject.FindProperty("_changedWithHistory").objectReferenceValue;
+                EditorGUILayout.PropertyField(serializedObject.FindProperty("ChangedWithHistory"));
+                var changedWithHistory = serializedObject.FindProperty("ChangedWithHistory").objectReferenceValue;
                 if (changedWithHistory != null && changedWithHistory is AtomEventBase evt && target is AtomBaseVariable atomTarget)
                 {
                     GUILayout.Space(2);

--- a/Packages/Core/Editor/Extensions/SerializedPropertyExtensions.cs
+++ b/Packages/Core/Editor/Extensions/SerializedPropertyExtensions.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Collections;
 using UnityEditor;
 using UnityEngine;
+using System.Text.RegularExpressions;
 
 namespace UnityAtoms.Editor
 {
@@ -124,6 +125,12 @@ namespace UnityAtoms.Editor
             }
         }
 
+        public static object GetTopParent(this SerializedProperty property)
+        {
+            object obj = property.serializedObject.targetObject;
+            return obj;
+        }
+
         public static object GetParent(this SerializedProperty property)
         {
             var path = property.propertyPath.Replace(".Array.data[", "[");
@@ -164,6 +171,8 @@ namespace UnityAtoms.Editor
         public static object GetValue(this object source, string name, int index)
         {
             var enumerable = GetValue(source, name) as IEnumerable;
+            if (enumerable == null)
+                return null;
             var enm = enumerable.GetEnumerator();
             while (index-- >= 0)
                 enm.MoveNext();

--- a/Packages/Core/Editor/Utils/AtomFuser.cs
+++ b/Packages/Core/Editor/Utils/AtomFuser.cs
@@ -1,0 +1,72 @@
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+namespace UnityAtoms.Editor
+{
+    public static class AtomFuser
+    {
+        public static bool IsValidFuse(BaseAtom ab)
+        {
+            var variablePath = AssetDatabase.GetAssetOrScenePath(ab);
+            var destinationPath = variablePath.Replace($"/{ab.name}.asset", "");
+            if (destinationPath.EndsWith(".asset"))
+            {
+                return false;
+            }
+            else
+            {
+                return true;
+            }
+        }
+
+        public static Object FindSubAsset(Object parent, Object assetToFind)
+        {
+            Object[] objs = AssetDatabase.LoadAllAssetsAtPath(AssetDatabase.GetAssetPath(parent));
+            for (int i = 0; i < objs.Length; i++)
+            {
+                Object item = objs[i];
+                if (assetToFind.Equals(item))
+                {
+                    return item;
+                }
+            }
+            return default;
+        }
+
+        public static bool IsFused(SerializedProperty property, BaseAtom ab)
+        {
+            return FindSubAsset(ab, property.objectReferenceValue) != null;
+        }
+
+        public static void FuseAtom(SerializedProperty property, BaseAtom ab)
+        {
+            var sourceIsMain = AssetDatabase.IsMainAsset(property.objectReferenceValue);
+            var sourcePath = AssetDatabase.GetAssetPath(property.objectReferenceValue);
+            AssetDatabase.RemoveObjectFromAsset(property.objectReferenceValue);
+            AssetDatabase.AddObjectToAsset(property.objectReferenceValue, ab);
+
+            if (sourceIsMain)
+            {
+                AssetDatabase.DeleteAsset(sourcePath);
+            }
+            EditorGUIUtility.PingObject(property.objectReferenceInstanceIDValue);
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
+        }
+
+        public static void DiffuseAtom(SerializedProperty property, BaseAtom ab)
+        {
+            var variablePath = AssetDatabase.GetAssetOrScenePath(ab);
+            var destinationPath = variablePath.Replace($"/{ab.name}.asset", "");
+            var assetName = property.objectReferenceValue.name + ".asset";
+            var assetPath = Path.Combine(destinationPath, assetName);
+            var assetUniquePath = AssetDatabase.GenerateUniqueAssetPath(assetPath);
+            AssetDatabase.RemoveObjectFromAsset(property.objectReferenceValue);
+            AssetDatabase.CreateAsset(property.objectReferenceValue, assetUniquePath);
+            EditorGUIUtility.PingObject(property.objectReferenceInstanceIDValue);
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
+        }
+    }
+}

--- a/Packages/Core/Editor/Utils/AtomFuser.cs.meta
+++ b/Packages/Core/Editor/Utils/AtomFuser.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a46aac5075a70294f9ba17a593dbb14f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/Core/Editor/Utils/AtomNameUtils.cs
+++ b/Packages/Core/Editor/Utils/AtomNameUtils.cs
@@ -1,0 +1,34 @@
+using System.Text.RegularExpressions;
+using UnityEditor;
+
+namespace UnityAtoms.Editor
+{
+    public static class AtomNameUtils
+    {
+        public static string FilterLastIndexOf(string result, string identifier)
+        {
+            return result.Contains(identifier) ? result.Substring(result.LastIndexOf(identifier) + 1) : result;
+        }
+
+        public static string CleanPropertyName(string propertyName)
+        {
+            string cleanedProperty = propertyName;
+            if (propertyName[0].ToString() == "_")
+            {
+                cleanedProperty = propertyName.Substring(1);
+            }
+            if (Regex.Match(cleanedProperty, @"[a-zA-Z]").Success)
+            {
+                var index = Regex.Match(cleanedProperty, @"[a-zA-Z]").Index;
+                cleanedProperty = cleanedProperty[index].ToString().ToUpper() + cleanedProperty.Substring(index + 1);
+            }
+            return cleanedProperty;
+        }
+
+        public static string CheckForDuplicateAtom(string atomName)
+        {
+            var results = AssetDatabase.FindAssets(atomName);
+            return results.Length > 0 ? $"{atomName} ({results.Length})" : atomName;
+        }
+    }
+}

--- a/Packages/Core/Editor/Utils/AtomNameUtils.cs.meta
+++ b/Packages/Core/Editor/Utils/AtomNameUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 98c434bc20ac1fd44b961ac930ead4bc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/Core/Runtime/Attributes/HideCreate.cs
+++ b/Packages/Core/Runtime/Attributes/HideCreate.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+namespace UnityAtoms
+{
+    public class HideCreate : PropertyAttribute
+    {
+    }
+
+}

--- a/Packages/Core/Runtime/Attributes/HideCreate.cs
+++ b/Packages/Core/Runtime/Attributes/HideCreate.cs
@@ -1,9 +1,8 @@
+using System;
 using UnityEngine;
 
 namespace UnityAtoms
 {
-    public class HideCreate : PropertyAttribute
-    {
-    }
-
+    [AttributeUsage(AttributeTargets.Field)]
+    public class HideCreate : PropertyAttribute {}
 }

--- a/Packages/Core/Runtime/Attributes/HideCreate.cs.meta
+++ b/Packages/Core/Runtime/Attributes/HideCreate.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a59749ce16d201f45b98a35ece400308
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/Core/Runtime/Attributes/ObjectFieldSubType.cs
+++ b/Packages/Core/Runtime/Attributes/ObjectFieldSubType.cs
@@ -1,0 +1,13 @@
+using System;
+using UnityEngine;
+
+[AttributeUsage(AttributeTargets.Field)]
+public class ObjectFieldSubType : PropertyAttribute
+{
+    public Type SubType;
+
+    public ObjectFieldSubType(Type subType)
+    {
+        SubType = subType;
+    }
+}

--- a/Packages/Core/Runtime/Attributes/ObjectFieldSubType.cs.meta
+++ b/Packages/Core/Runtime/Attributes/ObjectFieldSubType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 59dce7620906666419c32b0cc7937fb3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/FSM/Editor/Editors/FiniteStateMachineEditor.cs
+++ b/Packages/FSM/Editor/Editors/FiniteStateMachineEditor.cs
@@ -37,8 +37,8 @@ namespace UnityAtoms.FSM.Editor
             const int raiseButtonWidth = 52;
             using (new EditorGUILayout.HorizontalScope())
             {
-                EditorGUILayout.PropertyField(serializedObject.FindProperty("_changed"));
-                var changed = serializedObject.FindProperty("_changed").objectReferenceValue;
+                EditorGUILayout.PropertyField(serializedObject.FindProperty("Changed"));
+                var changed = serializedObject.FindProperty("Changed").objectReferenceValue;
                 if (changed != null && changed is AtomEventBase evt && target is AtomBaseVariable atomTarget)
                 {
                     GUILayout.Space(2);
@@ -52,8 +52,8 @@ namespace UnityAtoms.FSM.Editor
 
             using (new EditorGUILayout.HorizontalScope())
             {
-                EditorGUILayout.PropertyField(serializedObject.FindProperty("_changedWithHistory"));
-                var changedWithHistory = serializedObject.FindProperty("_changedWithHistory").objectReferenceValue;
+                EditorGUILayout.PropertyField(serializedObject.FindProperty("ChangedWithHistory"));
+                var changedWithHistory = serializedObject.FindProperty("ChangedWithHistory").objectReferenceValue;
                 if (changedWithHistory != null && changedWithHistory is AtomEventBase evt && target is AtomBaseVariable atomTarget)
                 {
 

--- a/Packages/FSM/Runtime/FiniteStateMachine/FSMState.cs
+++ b/Packages/FSM/Runtime/FiniteStateMachine/FSMState.cs
@@ -21,7 +21,7 @@ namespace UnityAtoms.FSM
         [SerializeField]
         private AtomReference<float> _cooldown = new AtomReference<float>(0f);
 
-        [SerializeField]
+        [SerializeField, HideCreate]
         private FiniteStateMachine _subMachine = default(FiniteStateMachine);
     }
 }


### PR DESCRIPTION
This PR is the V5 upgrade of my earlier uploaded PR's. I did a rewrite of the AtomDrawer Class and added a few things.

- New Variables and Events that are created in the inspector get a default pre configured name.
- New Variables and Events are automatically fused as a subasset. The UI for this is implemented too.
- Implemented Typecache API to convert ObjectFields back into their correct type as they work in V4.

- Added a [HideCreate] propertyAttribute to disable the create button for certain fields in the inspector (like Items in the AtomList/AtomCollection and the Submachine ObjectField in the FSM state).

- Added a ObjectFieldSubType property attribute to convert the inspector objectfields into the right type. In e.g. AtomList and AtomCollection the items in the list and collection were of type AtomBaseVariableList. They should be AtomBaseVariable. This property attribute makes sure of that.

All feedback is appreciated. This version now should already work quite good. 

This PR should be a fix for #290  , #67  , #149 and @AdamRamberg 's concerns about  the Unity Editor search functionality for subclasses https://forum.unity.com/threads/generics-serialization.746300/page-2#post-5858386  


Questions:

Fusing multiple Boolvariables on the FSM works. But the code now has some quirks doing this. I'd love some feedbakc to improve this even more or this PR in general :).

Do we want the Changed and ChangedWithHistory variables as properties or as it is now by using public? In V5 I saw it was changed to public but I don't if this was on pupose or not.
