### PR TITLE
#347 [fix]: conditional compilation for EDITOR only code

### DIFF
--- a/Packages/Core/Runtime/StackTrace/StackTraceEntry.cs
+++ b/Packages/Core/Runtime/StackTrace/StackTraceEntry.cs
@@ -60,10 +60,15 @@ namespace UnityAtoms
             }
         }
 
+#if UNITY_EDITOR
         public static StackTraceEntry Create(object obj, int skipFrames = 0) => AtomPreferences.IsDebugModeEnabled ? new StackTraceEntry(new StackTrace(skipFrames), obj) : null;
 
         public static StackTraceEntry Create(int skipFrames = 0) => AtomPreferences.IsDebugModeEnabled ? new StackTraceEntry(new StackTrace(skipFrames)) : null;
+#else
+        public static StackTraceEntry Create(object obj, int skipFrames = 0) => null;
 
+        public static StackTraceEntry Create(int skipFrames = 0) => null;
+#endif
 
         public override bool Equals(object obj) => Equals(obj as StackTraceEntry);
 


### PR DESCRIPTION
fixes #347 

> PR https://github.com/unity-atoms/unity-atoms/pull/329 made the projects unable to compile in builds:
> 
> as the lines require AtomPreferences.IsDebugModeEnabled
> https://github.com/unity-atoms/unity-atoms/blob/v4.4.4/Packages/Core/Runtime/StackTrace/StackTraceEntry.cs#L63=
> 
> but due to conditional compilation:
> https://github.com/unity-atoms/unity-atoms/blob/v4.4.4/Packages/Core/Runtime/Preferences/AtomsPreferences.cs#L1=
> 
> this does not exist in builds