### PR TITLE
fix: #353 "Vector2/3 reference not properly showing"

### DIFF
--- a/Packages/Core/Editor/Drawers/AtomBaseReferenceDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomBaseReferenceDrawer.cs
@@ -56,6 +56,7 @@ namespace UnityAtoms.Editor
             // Calculate rect for configuration button
             Rect buttonRect = new Rect(position);
             buttonRect.yMin += _popupStyle.margin.top;
+            buttonRect.yMax = buttonRect.yMin + EditorGUIUtility.singleLineHeight;
             buttonRect.width = _popupStyle.fixedWidth + _popupStyle.margin.right;
             position.xMin = buttonRect.xMax;
 
@@ -75,7 +76,7 @@ namespace UnityAtoms.Editor
             var valueFieldHeight = EditorGUI.GetPropertyHeight(usageTypeProperty, label);
             usageTypeProperty.isExpanded = expanded;
 
-            if (usageTypePropertyName == "_value" && valueFieldHeight > EditorGUIUtility.singleLineHeight+2)
+            if (usageTypePropertyName == "_value" && valueFieldHeight > EditorGUIUtility.singleLineHeight + 2)
             {
                 EditorGUI.PropertyField(originalPosition, usageTypeProperty, GUIContent.none, true);
             }

--- a/Packages/Core/Editor/Drawers/AtomBaseReferenceDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomBaseReferenceDrawer.cs
@@ -70,9 +70,14 @@ namespace UnityAtoms.Editor
             var usageTypePropertyName = GetUsages(property)[newUsageValue].PropertyName;
             var usageTypeProperty = property.FindPropertyRelative(usageTypePropertyName);
 
-            if (usageTypePropertyName == "_value")
+            var expanded = usageTypeProperty.isExpanded;
+            usageTypeProperty.isExpanded = true;
+            var valueFieldHeight = EditorGUI.GetPropertyHeight(usageTypeProperty, label);
+            usageTypeProperty.isExpanded = expanded;
+
+            if (usageTypePropertyName == "_value" && valueFieldHeight > EditorGUIUtility.singleLineHeight+2)
             {
-                EditorGUI.PropertyField(usageTypeProperty.hasChildren ? originalPosition : position, usageTypeProperty, GUIContent.none, true);
+                EditorGUI.PropertyField(originalPosition, usageTypeProperty, GUIContent.none, true);
             }
             else
             {


### PR DESCRIPTION
fixes #353 and #357

The code before https://github.com/unity-atoms/unity-atoms/pull/289 has handled properties with custom-one-line-drawers (like Vector3) correctly, but did not handle custom structs - when collapsed - correctly.

this fix is the best of both worlds: 
- Get the property height of the property if it would be expanded, 
- then decided based upon whether or not it _would_ occupy multiple lines.

![image](https://user-images.githubusercontent.com/3066582/175772046-f5c937f2-ec3f-4ac8-a7a6-196d0d7b6815.png)

![image](https://user-images.githubusercontent.com/3066582/175772051-f84f992e-d492-4364-b184-7727191650a6.png)

this also fixes the broken StringReferences mentioned in (#357)

![image](https://user-images.githubusercontent.com/3066582/175772095-6e573c8d-3be5-45f8-94df-09d39fee82b4.png)

