### PR TITLE
fix: fix property drawer for unity struct references

### DIFF
--- a/Packages/Core/Editor/Drawers/AtomBaseReferenceDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomBaseReferenceDrawer.cs
@@ -72,7 +72,9 @@ namespace UnityAtoms.Editor
 
             if (usageTypePropertyName == "_value")
             {
-                EditorGUI.PropertyField(usageTypeProperty.hasChildren ? originalPosition : position, usageTypeProperty, GUIContent.none, true);
+                var hasChildren = usageTypeProperty.hasChildren &&
+                    usageTypeProperty.propertyType == SerializedPropertyType.Generic;
+                EditorGUI.PropertyField(hasChildren ? originalPosition : position, usageTypeProperty, GUIContent.none, true);
             }
             else
             {


### PR DESCRIPTION
Reference types for some Unity structs (Vector2, Vector3 etc.) weren't drawing correctly. Fixes #367

![image](https://user-images.githubusercontent.com/6034931/186015294-e23c73ed-b8a0-47fc-bd51-52b7075880eb.png)