### PR TITLE
removed ondisable method, to fix #349

### DIFF
--- a/Packages/Core/Runtime/Variables/AtomVariable.cs
+++ b/Packages/Core/Runtime/Variables/AtomVariable.cs
@@ -47,7 +47,6 @@ namespace UnityAtoms
         [SerializeField]
         [FormerlySerializedAs("Changed")]
         private E1 _changed;
-        private bool _changedInstantiatedAtRuntime;
         public E1 Changed
         {
             get
@@ -67,7 +66,6 @@ namespace UnityAtoms
         [SerializeField]
         [FormerlySerializedAs("ChangedWithHistory")]
         private E2 _changedWithHistory;
-        private bool _changedWithHistoryInstantiatedAtRuntime;
         public E2 ChangedWithHistory
         {
             get
@@ -164,9 +162,6 @@ namespace UnityAtoms
         {
             _oldValue = InitialValue;
             _value = InitialValue;
-
-            _changedInstantiatedAtRuntime = false;
-            _changedWithHistoryInstantiatedAtRuntime = false;
         }
 
         /// <summary>
@@ -183,7 +178,7 @@ namespace UnityAtoms
             }
             if (_triggerChangedWithHistoryOnOnEnable)
             {
-                if(ChangedWithHistory == null)
+                if (ChangedWithHistory == null)
                     GetOrCreateEvent<E2>();
 
                 var pair = default(P);
@@ -385,7 +380,6 @@ namespace UnityAtoms
                 {
                     _changed = ScriptableObject.CreateInstance<E1>();
                     _changed.name = $"{(String.IsNullOrWhiteSpace(name) ? "" : $"{name}_")}ChangedEvent_Runtime_{typeof(E1)}";
-                    _changedInstantiatedAtRuntime = true;
                 }
 
                 return _changed as E;
@@ -396,7 +390,6 @@ namespace UnityAtoms
                 {
                     _changedWithHistory = ScriptableObject.CreateInstance<E2>();
                     _changedWithHistory.name = $"{(String.IsNullOrWhiteSpace(name) ? "" : $"{name}_")}ChangedWithHistoryEvent_Runtime_{typeof(E2)}";
-                    _changedWithHistoryInstantiatedAtRuntime = true;
                 }
 
                 return _changedWithHistory as E;

--- a/Packages/Core/Runtime/Variables/AtomVariable.cs
+++ b/Packages/Core/Runtime/Variables/AtomVariable.cs
@@ -156,11 +156,6 @@ namespace UnityAtoms
 #endif
         }
 
-        private void OnDisable()
-        {
-            if (_changedInstantiatedAtRuntime) _changed = null;
-            if (_changedWithHistoryInstantiatedAtRuntime) _changedWithHistory = null;
-        }
 
         /// <summary>
         /// Set initial values


### PR DESCRIPTION
this addresses #349 and fixes an issue introduced with #303 

when starting the runtime without changed event, it would set the "_changedInstantiatedAtRuntime" to true.

OnDisable is only called if you hit play again and are about to enter the playmode again, which then RESETS all your changes (e.g. assigning an event in edit time) to null. 

the alternative would be to address this in the custom editor drawer, to set _changedInstantiatedAtRuntime to false again when _changed was set.

but I found that the OnDisable was not needed, as the values where already set back when leaving playmode and in the build (which i have not tested!! it wouldn't matter anyways since OnDisable is only called if the memory is freed altogether) 

