### PR TITLE
prevent null reference exceptions in editor when using not-serializab…

### DIFF
--- a/Packages/Core/Editor/Drawers/AtomBaseReferenceDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomBaseReferenceDrawer.cs
@@ -59,6 +59,7 @@ namespace UnityAtoms.Editor
             // Calculate rect for configuration button
             Rect buttonRect = new Rect(position);
             buttonRect.yMin += _popupStyle.margin.top;
+            buttonRect.yMax = buttonRect.yMin + EditorGUIUtility.singleLineHeight;
             buttonRect.width = _popupStyle.fixedWidth + _popupStyle.margin.right;
             position.xMin = buttonRect.xMax;
 
@@ -73,7 +74,7 @@ namespace UnityAtoms.Editor
             var usageTypePropertyName = GetUsages(property)[newUsageValue].PropertyName;
             var usageTypeProperty = property.FindPropertyRelative(usageTypePropertyName);
 
-            if(usageTypeProperty == null)
+            if (usageTypeProperty == null)
             {
                 EditorGUI.LabelField(position, "[Non serialized value]");
             }
@@ -84,7 +85,7 @@ namespace UnityAtoms.Editor
                 var valueFieldHeight = EditorGUI.GetPropertyHeight(usageTypeProperty, label);
                 usageTypeProperty.isExpanded = expanded;
 
-                if (usageTypePropertyName == "_value" && (valueFieldHeight > EditorGUIUtility.singleLineHeight+2))
+                if (usageTypePropertyName == "_value" && (valueFieldHeight > EditorGUIUtility.singleLineHeight + 2))
                 {
                     EditorGUI.PropertyField(originalPosition, usageTypeProperty, GUIContent.none, true);
                 }

--- a/Packages/Core/Editor/Drawers/AtomBaseReferenceDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomBaseReferenceDrawer.cs
@@ -35,7 +35,10 @@ namespace UnityAtoms.Editor
                 }
             }
 
-            return EditorGUI.GetPropertyHeight(property.FindPropertyRelative(usageData.PropertyName), label);
+            var innerProperty = property.FindPropertyRelative(usageData.PropertyName);
+            return innerProperty == null ?
+                EditorGUIUtility.singleLineHeight :
+                EditorGUI.GetPropertyHeight(innerProperty, label);
         }
 
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
@@ -56,7 +59,6 @@ namespace UnityAtoms.Editor
             // Calculate rect for configuration button
             Rect buttonRect = new Rect(position);
             buttonRect.yMin += _popupStyle.margin.top;
-            buttonRect.yMax = buttonRect.yMin + EditorGUIUtility.singleLineHeight;
             buttonRect.width = _popupStyle.fixedWidth + _popupStyle.margin.right;
             position.xMin = buttonRect.xMax;
 
@@ -71,20 +73,26 @@ namespace UnityAtoms.Editor
             var usageTypePropertyName = GetUsages(property)[newUsageValue].PropertyName;
             var usageTypeProperty = property.FindPropertyRelative(usageTypePropertyName);
 
-            var expanded = usageTypeProperty.isExpanded;
-            usageTypeProperty.isExpanded = true;
-            var valueFieldHeight = EditorGUI.GetPropertyHeight(usageTypeProperty, label);
-            usageTypeProperty.isExpanded = expanded;
-
-            if (usageTypePropertyName == "_value" && valueFieldHeight > EditorGUIUtility.singleLineHeight + 2)
+            if(usageTypeProperty == null)
             {
-                EditorGUI.PropertyField(originalPosition, usageTypeProperty, GUIContent.none, true);
+                EditorGUI.LabelField(position, "[Non serialized value]");
             }
             else
             {
-                EditorGUI.PropertyField(position, usageTypeProperty, GUIContent.none);
-            }
+                var expanded = usageTypeProperty.isExpanded;
+                usageTypeProperty.isExpanded = true;
+                var valueFieldHeight = EditorGUI.GetPropertyHeight(usageTypeProperty, label);
+                usageTypeProperty.isExpanded = expanded;
 
+                if (usageTypePropertyName == "_value" && (valueFieldHeight > EditorGUIUtility.singleLineHeight+2))
+                {
+                    EditorGUI.PropertyField(originalPosition, usageTypeProperty, GUIContent.none, true);
+                }
+                else
+                {
+                    EditorGUI.PropertyField(position, usageTypeProperty, GUIContent.none);
+                }
+            }
             if (EditorGUI.EndChangeCheck())
                 property.serializedObject.ApplyModifiedProperties();
 

--- a/Packages/Core/Editor/Drawers/VariableDrawer.cs
+++ b/Packages/Core/Editor/Drawers/VariableDrawer.cs
@@ -20,14 +20,15 @@ namespace UnityAtoms.Editor
             var inner = new SerializedObject(property.objectReferenceValue);
             var valueProp = inner.FindProperty("_value");
             Rect previewRect = new Rect(position);
-            previewRect.width = GetPreviewSpace(valueProp == null ? "" : valueProp.type);
+            previewRect.width = GetPreviewSpace(valueProp?.type);
             position.xMin = previewRect.xMax;
 
             int indent = EditorGUI.indentLevel;
             EditorGUI.indentLevel = 0;
 
             EditorGUI.BeginDisabledGroup(true);
-            if(valueProp != null){
+            if (valueProp != null)
+            {
                 EditorGUI.PropertyField(previewRect, valueProp, GUIContent.none, false);
             }
             else

--- a/Packages/Core/Editor/Drawers/VariableDrawer.cs
+++ b/Packages/Core/Editor/Drawers/VariableDrawer.cs
@@ -19,16 +19,21 @@ namespace UnityAtoms.Editor
 
             var inner = new SerializedObject(property.objectReferenceValue);
             var valueProp = inner.FindProperty("_value");
-            var width = GetPreviewSpace(valueProp.type);
             Rect previewRect = new Rect(position);
-            previewRect.width = GetPreviewSpace(valueProp.type);
+            previewRect.width = GetPreviewSpace(valueProp == null ? "" : valueProp.type);
             position.xMin = previewRect.xMax;
 
             int indent = EditorGUI.indentLevel;
             EditorGUI.indentLevel = 0;
 
             EditorGUI.BeginDisabledGroup(true);
-            EditorGUI.PropertyField(previewRect, valueProp, GUIContent.none, false);
+            if(valueProp != null){
+                EditorGUI.PropertyField(previewRect, valueProp, GUIContent.none, false);
+            }
+            else
+            {
+                EditorGUI.LabelField(previewRect, "[Non serialized value]");
+            }
             EditorGUI.EndDisabledGroup();
 
             position.x = position.x + 6f;

--- a/Packages/Core/Editor/Editors/Variables/AtomVariableEditor.cs
+++ b/Packages/Core/Editor/Editors/Variables/AtomVariableEditor.cs
@@ -14,15 +14,18 @@ namespace UnityAtoms.Editor
         private bool _lockedInitialValue = true;
         private bool _onEnableTriggerSectionVisible = true;
 
-        private void DrawPotentiallyUnserializablePropertyField(SerializedProperty property, bool includeChildren)
+        private void DrawPotentiallyUnserializablePropertyField(SerializedProperty property, bool drawWarningWhenUnserializable = false)
         {
             if (property == null)
             {
-                EditorGUILayout.HelpBox("Can't display values because the type is not serializable! You can still use this type, but won't be able to show values in the Editor.", MessageType.Warning);
+                if (drawWarningWhenUnserializable)
+                {
+                    EditorGUILayout.HelpBox("Can't display values because the type is not serializable! You can still use this type, but won't be able to show values in the Editor.", MessageType.Warning);
+                }
             }
             else
             {
-                EditorGUILayout.PropertyField(property, includeChildren);
+                EditorGUILayout.PropertyField(property, true);
             }
         }
 
@@ -38,7 +41,7 @@ namespace UnityAtoms.Editor
 
             EditorGUILayout.BeginHorizontal();
             EditorGUI.BeginDisabledGroup(_lockedInitialValue && EditorApplication.isPlayingOrWillChangePlaymode);
-            DrawPotentiallyUnserializablePropertyField(serializedObject.FindProperty("_initialValue"), true);
+            DrawPotentiallyUnserializablePropertyField(serializedObject.FindProperty("_initialValue"), drawWarningWhenUnserializable: true);
             EditorGUI.EndDisabledGroup();
             if (EditorApplication.isPlaying)
             {
@@ -50,7 +53,7 @@ namespace UnityAtoms.Editor
             using (new EditorGUI.DisabledGroupScope(!EditorApplication.isPlaying))
             {
                 EditorGUI.BeginChangeCheck();
-                DrawPotentiallyUnserializablePropertyField(serializedObject.FindProperty("_value"), true);
+                DrawPotentiallyUnserializablePropertyField(serializedObject.FindProperty("_value"));
                 if (EditorGUI.EndChangeCheck() && target is AtomBaseVariable atomTarget)
                 {
                     try
@@ -63,7 +66,7 @@ namespace UnityAtoms.Editor
                             atomTarget.BaseValue = (double)(float)value;
                         }
                         //Ulong is deserialized to System32 Int.
-                        else if(typeof(T) == typeof(ulong))
+                        else if (typeof(T) == typeof(ulong))
                         {
                             atomTarget.BaseValue = (ulong)(int)value;
                         }
@@ -85,7 +88,7 @@ namespace UnityAtoms.Editor
 
 
             EditorGUI.BeginDisabledGroup(true);
-            DrawPotentiallyUnserializablePropertyField(serializedObject.FindProperty("_oldValue"), true);
+            DrawPotentiallyUnserializablePropertyField(serializedObject.FindProperty("_oldValue"));
             EditorGUI.EndDisabledGroup();
 
             const int raiseButtonWidth = 52;

--- a/Packages/Core/Editor/Editors/Variables/AtomVariableEditor.cs
+++ b/Packages/Core/Editor/Editors/Variables/AtomVariableEditor.cs
@@ -13,9 +13,23 @@ namespace UnityAtoms.Editor
     {
         private bool _lockedInitialValue = true;
         private bool _onEnableTriggerSectionVisible = true;
+
+        private void DrawPotentiallyUnserializablePropertyField(SerializedProperty property, bool includeChildren)
+        {
+            if (property == null)
+            {
+                EditorGUILayout.HelpBox("Can't display values because the type is not serializable! You can still use this type, but won't be able to show values in the Editor.", MessageType.Warning);
+            }
+            else
+            {
+                EditorGUILayout.PropertyField(property, includeChildren);
+            }
+        }
+
         public override void OnInspectorGUI()
         {
             serializedObject.Update();
+
 
             EditorGUILayout.PropertyField(serializedObject.FindProperty("_developerDescription"));
             EditorGUILayout.Space();
@@ -24,7 +38,7 @@ namespace UnityAtoms.Editor
 
             EditorGUILayout.BeginHorizontal();
             EditorGUI.BeginDisabledGroup(_lockedInitialValue && EditorApplication.isPlayingOrWillChangePlaymode);
-            EditorGUILayout.PropertyField(serializedObject.FindProperty("_initialValue"), true);
+            DrawPotentiallyUnserializablePropertyField(serializedObject.FindProperty("_initialValue"), true);
             EditorGUI.EndDisabledGroup();
             if (EditorApplication.isPlaying)
             {
@@ -36,7 +50,7 @@ namespace UnityAtoms.Editor
             using (new EditorGUI.DisabledGroupScope(!EditorApplication.isPlaying))
             {
                 EditorGUI.BeginChangeCheck();
-                EditorGUILayout.PropertyField(serializedObject.FindProperty("_value"), true);
+                DrawPotentiallyUnserializablePropertyField(serializedObject.FindProperty("_value"), true);
                 if (EditorGUI.EndChangeCheck() && target is AtomBaseVariable atomTarget)
                 {
                     try
@@ -48,7 +62,7 @@ namespace UnityAtoms.Editor
                         {
                             atomTarget.BaseValue = (double)(float)value;
                         }
-                        //Ulong is deserialized to System32 Int. 
+                        //Ulong is deserialized to System32 Int.
                         else if(typeof(T) == typeof(ulong))
                         {
                             atomTarget.BaseValue = (ulong)(int)value;
@@ -71,7 +85,7 @@ namespace UnityAtoms.Editor
 
 
             EditorGUI.BeginDisabledGroup(true);
-            EditorGUILayout.PropertyField(serializedObject.FindProperty("_oldValue"), true);
+            DrawPotentiallyUnserializablePropertyField(serializedObject.FindProperty("_oldValue"), true);
             EditorGUI.EndDisabledGroup();
 
             const int raiseButtonWidth = 52;


### PR DESCRIPTION
this is taking only the relevant parts of PR #304. Special thanks to @IceTrooper.

I created a new PR to keep all the small refactoring changes out, which resulted in merge conflicts and much noise.

In AtomBaseReferenceDrawer > OnGUI: the diff looks like much, but I actually just wrapped the previous code in an if-else branch and I'm showing a label if the property is not serializable. the else branch is unchanged.

I suggest in the "files changed"-tab select the settings-icon and "hide whitespaces" so the indentation does not confuse the diff coloring

