### PR TITLE
FiniteStateMachineMonoHook unload fix

### DIFF
--- a/Packages/FSM/Runtime/FiniteStateMachine/FiniteStateMachineMonoHook.cs
+++ b/Packages/FSM/Runtime/FiniteStateMachine/FiniteStateMachineMonoHook.cs
@@ -14,6 +14,7 @@ namespace UnityAtoms.FSM
             {
                 GameObject go = new GameObject("FiniteStateMachineUpdateHook");
                 _instance = go.AddComponent<FiniteStateMachineMonoHook>();
+                DontDestroyOnLoad(go);
             }
 
             return _instance;


### PR DESCRIPTION
prevents FiniteStateMachineMonoHook singleton from being unloaded

fixes #385 