### PR TITLE
fix: Event Replay Buffer not cleared when domain reload disabled

### DIFF
--- a/Packages/Core/Runtime/Events/AtomEvent.cs
+++ b/Packages/Core/Runtime/Events/AtomEvent.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
 using UnityEngine;
 
 namespace UnityAtoms
@@ -34,6 +37,47 @@ namespace UnityAtoms
         private int _replayBufferSize = 1;
 
         private Queue<T> _replayBuffer = new Queue<T>();
+
+#if UNITY_EDITOR
+        /// <summary>
+        /// Set of all AtomVariable instances in editor.
+        /// </summary>
+        private static HashSet<AtomEvent<T>> _instances = new HashSet<AtomEvent<T>>();
+#endif
+
+        private void OnEnable()
+        {
+#if UNITY_EDITOR
+            if (EditorSettings.enterPlayModeOptionsEnabled)
+            {
+                _instances.Add(this);
+
+                EditorApplication.playModeStateChanged -= HandlePlayModeStateChange;
+                EditorApplication.playModeStateChanged += HandlePlayModeStateChange;
+            }
+#endif
+        }
+
+
+#if UNITY_EDITOR
+        private static void HandlePlayModeStateChange(PlayModeStateChange state)
+        {
+            if (state == PlayModeStateChange.ExitingEditMode)
+            {
+                foreach (var instance in _instances)
+                {
+                    instance._replayBuffer.Clear();
+                }
+            }
+            else if (state == PlayModeStateChange.EnteredPlayMode)
+            {
+                foreach (var instance in _instances)
+                {
+                    instance._replayBuffer.Clear();
+                }
+            }
+        }
+#endif
 
         private void OnDisable()
         {


### PR DESCRIPTION
this fixes a discrepancy between the AtomVariable and AtomEvent implementation.

While the AtomVariable handled disabled domain reload already (since 4.4.) AtomEvent still had their replay buffer persisting.
This was first mentioned in https://github.com/unity-atoms/unity-atoms/issues/146#issuecomment-813027910

steps to reproduce:
- disable domain reload
- add a variable to a listener and attach an action that logs the value.
- hit play, invoke the event.
- hit stop, and play again

result without this commit: the last value is logged. with this commit, the buffer is cleared correctly and no value is logged.

The implementation follows the one in AtomVariable.

fixes #146 
