### PR TITLE
Handling dead references when resetting objects.

### DIFF
--- a/Packages/Core/Runtime/Events/AtomEvent.cs
+++ b/Packages/Core/Runtime/Events/AtomEvent.cs
@@ -76,6 +76,7 @@ namespace UnityAtoms
 
         private void OnDisable()
         {
+            _instances.Remove(this);
             // Clear all delegates when exiting play mode
             UnregisterAll();
         }

--- a/Packages/Core/Runtime/Events/AtomEvent.cs
+++ b/Packages/Core/Runtime/Events/AtomEvent.cs
@@ -66,6 +66,11 @@ namespace UnityAtoms
             {
                 foreach (var instance in _instances)
                 {
+                    if (instance == null)
+                    {
+                        _instances.Remove(instance);
+                        continue;
+                    }
                     instance._replayBuffer.Clear();
                     instance.UnregisterAll();
                 }
@@ -74,6 +79,11 @@ namespace UnityAtoms
             {
                 foreach (var instance in _instances)
                 {
+                    if (instance == null)
+                    {
+                        _instances.Remove(instance);
+                        continue;
+                    }
                     instance._replayBuffer.Clear();
                     instance.UnregisterAll();
                 }

--- a/Packages/Core/Runtime/Events/AtomEvent.cs
+++ b/Packages/Core/Runtime/Events/AtomEvent.cs
@@ -62,28 +62,11 @@ namespace UnityAtoms
 #if UNITY_EDITOR
         private static void HandlePlayModeStateChange(PlayModeStateChange state)
         {
-            if (state == PlayModeStateChange.ExitingEditMode) // BEFORE any GO is initialized:
+            if (state == PlayModeStateChange.ExitingEditMode // BEFORE any GO is initialized:
+                || state == PlayModeStateChange.EnteredEditMode) // AFTER Playmode stopped
             {
                 foreach (var instance in _instances)
                 {
-                    if (instance == null)
-                    {
-                        _instances.Remove(instance);
-                        continue;
-                    }
-                    instance._replayBuffer.Clear();
-                    instance.UnregisterAll();
-                }
-            }
-            else if (state == PlayModeStateChange.EnteredEditMode) // AFTER Playmode stopped
-            {
-                foreach (var instance in _instances)
-                {
-                    if (instance == null)
-                    {
-                        _instances.Remove(instance);
-                        continue;
-                    }
                     instance._replayBuffer.Clear();
                     instance.UnregisterAll();
                 }

--- a/Packages/Core/Runtime/Events/AtomEvent.cs
+++ b/Packages/Core/Runtime/Events/AtomEvent.cs
@@ -62,7 +62,7 @@ namespace UnityAtoms
 #if UNITY_EDITOR
         private static void HandlePlayModeStateChange(PlayModeStateChange state)
         {
-            if (state == PlayModeStateChange.ExitingEditMode)
+            if (state == PlayModeStateChange.ExitingEditMode) // BEFORE any GO is initialized:
             {
                 foreach (var instance in _instances)
                 {
@@ -75,7 +75,7 @@ namespace UnityAtoms
                     instance.UnregisterAll();
                 }
             }
-            else if (state == PlayModeStateChange.EnteredPlayMode)
+            else if (state == PlayModeStateChange.EnteredEditMode) // AFTER Playmode stopped
             {
                 foreach (var instance in _instances)
                 {

--- a/Packages/Core/Runtime/Events/AtomEvent.cs
+++ b/Packages/Core/Runtime/Events/AtomEvent.cs
@@ -76,6 +76,10 @@ namespace UnityAtoms
 
         private void OnDisable()
         {
+            // NOTE: This will not be called when deleting the Atom from the editor.
+            // Therefore, there might still be null instances, but even though not ideal,
+            // it should not cause any problems.
+            // More info: https://issuetracker.unity3d.com/issues/ondisable-and-ondestroy-methods-are-not-called-when-a-scriptableobject-is-deleted-manually-in-project-window
             _instances.Remove(this);
             // Clear all delegates when exiting play mode
             UnregisterAll();

--- a/Packages/Core/Runtime/ValueLists/AtomValueList.cs
+++ b/Packages/Core/Runtime/ValueLists/AtomValueList.cs
@@ -74,11 +74,6 @@ namespace UnityAtoms
             {
                 foreach (var instance in _instances)
                 {
-                    if (instance == null)
-                    {
-                        _instances.Remove(instance);
-                        continue;
-                    }
                     if(instance._startCleared) instance.list.Clear();
                     instance._initial = instance.list.ToList();
                 }
@@ -87,11 +82,6 @@ namespace UnityAtoms
             {                
                 foreach (var instance in _instances)
                 {
-                    if (instance == null) // might be for UnityEngine.Objects
-                    {
-                        _instances.Remove(instance);
-                        continue;
-                    }
                     instance.list = instance._initial;
                 }
             }

--- a/Packages/Core/Runtime/ValueLists/AtomValueList.cs
+++ b/Packages/Core/Runtime/ValueLists/AtomValueList.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
 using UnityEngine;
 
 namespace UnityAtoms
@@ -42,6 +44,49 @@ namespace UnityAtoms
         [SerializeField]
         protected List<T> list = new List<T>();
 
+        private List<T> _initial;
+        
+        
+#if UNITY_EDITOR
+        /// <summary>
+        /// Set of all AtomVariable instances in editor.
+        /// </summary>
+        private static HashSet<AtomValueList<T, E>> _instances = new HashSet<AtomValueList<T, E>>();
+#endif
+        
+        protected virtual void OnEnable()
+        {
+#if UNITY_EDITOR
+            if (EditorSettings.enterPlayModeOptionsEnabled)
+            {
+                _instances.Add(this);
+
+                EditorApplication.playModeStateChanged -= HandlePlayModeStateChange;
+                EditorApplication.playModeStateChanged += HandlePlayModeStateChange;
+            }
+#endif
+        }
+        
+#if UNITY_EDITOR
+        private static void HandlePlayModeStateChange(PlayModeStateChange state)
+        {
+            if (state == PlayModeStateChange.ExitingEditMode) // BEFORE any GO is initialized:
+            {
+                foreach (var instance in _instances)
+                {
+                    if(instance._startCleared) instance.list.Clear();
+                    instance._initial = instance.list.ToList();
+                }
+            }
+            else if (state == PlayModeStateChange.EnteredEditMode) // AFTER Playmode stopped
+            {                
+                foreach (var instance in _instances)
+                {
+                    instance.list = instance._initial;
+                }
+            }
+        }
+#endif
         /// <summary>
         /// Add an item to the list.
         /// </summary>

--- a/Packages/Core/Runtime/ValueLists/AtomValueList.cs
+++ b/Packages/Core/Runtime/ValueLists/AtomValueList.cs
@@ -70,6 +70,10 @@ namespace UnityAtoms
 
         private void OnDisable()
         {
+            // NOTE: This will not be called when deleting the Atom from the editor.
+            // Therefore, there might still be null instances, but even though not ideal,
+            // it should not cause any problems.
+            // More info: https://issuetracker.unity3d.com/issues/ondisable-and-ondestroy-methods-are-not-called-when-a-scriptableobject-is-deleted-manually-in-project-window
             _instances.Remove(this);
         }
 

--- a/Packages/Core/Runtime/ValueLists/AtomValueList.cs
+++ b/Packages/Core/Runtime/ValueLists/AtomValueList.cs
@@ -54,8 +54,9 @@ namespace UnityAtoms
         private static HashSet<AtomValueList<T, E>> _instances = new HashSet<AtomValueList<T, E>>();
 #endif
         
-        protected virtual void OnEnable()
+        protected override void OnEnable()
         {
+            base.OnEnable();
 #if UNITY_EDITOR
             if (EditorSettings.enterPlayModeOptionsEnabled)
             {
@@ -66,7 +67,12 @@ namespace UnityAtoms
             }
 #endif
         }
-        
+
+        private void OnDisable()
+        {
+            _instances.Remove(this);
+        }
+
 #if UNITY_EDITOR
         private static void HandlePlayModeStateChange(PlayModeStateChange state)
         {

--- a/Packages/Core/Runtime/ValueLists/AtomValueList.cs
+++ b/Packages/Core/Runtime/ValueLists/AtomValueList.cs
@@ -74,6 +74,11 @@ namespace UnityAtoms
             {
                 foreach (var instance in _instances)
                 {
+                    if (instance == null)
+                    {
+                        _instances.Remove(instance);
+                        continue;
+                    }
                     if(instance._startCleared) instance.list.Clear();
                     instance._initial = instance.list.ToList();
                 }
@@ -82,6 +87,11 @@ namespace UnityAtoms
             {                
                 foreach (var instance in _instances)
                 {
+                    if (instance == null) // might be for UnityEngine.Objects
+                    {
+                        _instances.Remove(instance);
+                        continue;
+                    }
                     instance.list = instance._initial;
                 }
             }

--- a/Packages/Core/Runtime/ValueLists/BaseAtomValueList.cs
+++ b/Packages/Core/Runtime/ValueLists/BaseAtomValueList.cs
@@ -32,7 +32,7 @@ namespace UnityAtoms
                 Cleared.Raise();
             }
         }
-        private void OnEnable()
+        protected virtual void OnEnable()
         {
             if (_startCleared)
             {

--- a/Packages/Core/Runtime/Variables/AtomVariable.cs
+++ b/Packages/Core/Runtime/Variables/AtomVariable.cs
@@ -196,6 +196,11 @@ namespace UnityAtoms
             {
                 foreach (var instance in _instances)
                 {
+                    if (instance == null)
+                    {
+                        _instances.Remove(instance);
+                        continue;
+                    }
                     instance.SetInitialValues();
                 }
             }
@@ -203,6 +208,11 @@ namespace UnityAtoms
             {
                 foreach (var instance in _instances)
                 {
+                    if (instance == null)
+                    {
+                        _instances.Remove(instance);
+                        continue;
+                    }
                     instance.TriggerInitialEvents();
                 };
             }

--- a/Packages/Core/Runtime/Variables/AtomVariable.cs
+++ b/Packages/Core/Runtime/Variables/AtomVariable.cs
@@ -192,7 +192,7 @@ namespace UnityAtoms
 #if UNITY_EDITOR
         private static void HandlePlayModeStateChange(PlayModeStateChange state)
         {
-            if (state == PlayModeStateChange.ExitingEditMode)
+            if (state == PlayModeStateChange.ExitingEditMode)  // BEFORE any GO is initialized:
             {
                 foreach (var instance in _instances)
                 {
@@ -204,7 +204,7 @@ namespace UnityAtoms
                     instance.SetInitialValues();
                 }
             }
-            else if (state == PlayModeStateChange.EnteredPlayMode)
+            else if (state == PlayModeStateChange.EnteredPlayMode)  // within/end of the first frame
             {
                 foreach (var instance in _instances)
                 {

--- a/Packages/Core/Runtime/Variables/AtomVariable.cs
+++ b/Packages/Core/Runtime/Variables/AtomVariable.cs
@@ -154,6 +154,10 @@ namespace UnityAtoms
 #endif
         }
 
+        private void OnDisable()
+        {
+            _instances.Remove(this);
+        }
 
         /// <summary>
         /// Set initial values
@@ -196,11 +200,6 @@ namespace UnityAtoms
             {
                 foreach (var instance in _instances)
                 {
-                    if (instance == null)
-                    {
-                        _instances.Remove(instance);
-                        continue;
-                    }
                     instance.SetInitialValues();
                 }
             }
@@ -208,11 +207,6 @@ namespace UnityAtoms
             {
                 foreach (var instance in _instances)
                 {
-                    if (instance == null)
-                    {
-                        _instances.Remove(instance);
-                        continue;
-                    }
                     instance.TriggerInitialEvents();
                 };
             }

--- a/Packages/Core/Runtime/Variables/AtomVariable.cs
+++ b/Packages/Core/Runtime/Variables/AtomVariable.cs
@@ -156,6 +156,10 @@ namespace UnityAtoms
 
         private void OnDisable()
         {
+            // NOTE: This will not be called when deleting the Atom from the editor.
+            // Therefore, there might still be null instances, but even though not ideal,
+            // it should not cause any problems.
+            // More info: https://issuetracker.unity3d.com/issues/ondisable-and-ondestroy-methods-are-not-called-when-a-scriptableobject-is-deleted-manually-in-project-window 
             _instances.Remove(this);
         }
 


### PR DESCRIPTION
Fixes: #417

Objects might be null (as they are unity objects) after an asset is deleted (or an AtomInstancer deleted it's runtime asset) - so these assets would through NRE when resetting with disabled domain reload.

the NRE would also prevent the other objects to reset correctly