### PR TITLE
Fix "The name '_instances' does not exist in the current context"

### DIFF
--- a/Packages/Core/Runtime/Events/AtomEvent.cs
+++ b/Packages/Core/Runtime/Events/AtomEvent.cs
@@ -80,7 +80,9 @@ namespace UnityAtoms
             // Therefore, there might still be null instances, but even though not ideal,
             // it should not cause any problems.
             // More info: https://issuetracker.unity3d.com/issues/ondisable-and-ondestroy-methods-are-not-called-when-a-scriptableobject-is-deleted-manually-in-project-window
+#if UNITY_EDITOR
             _instances.Remove(this);
+#endif
             // Clear all delegates when exiting play mode
             UnregisterAll();
         }

--- a/Packages/Core/Runtime/ValueLists/AtomValueList.cs
+++ b/Packages/Core/Runtime/ValueLists/AtomValueList.cs
@@ -74,7 +74,9 @@ namespace UnityAtoms
             // Therefore, there might still be null instances, but even though not ideal,
             // it should not cause any problems.
             // More info: https://issuetracker.unity3d.com/issues/ondisable-and-ondestroy-methods-are-not-called-when-a-scriptableobject-is-deleted-manually-in-project-window
+#if UNITY_EDITOR
             _instances.Remove(this);
+#endif
         }
 
 #if UNITY_EDITOR

--- a/Packages/Core/Runtime/Variables/AtomVariable.cs
+++ b/Packages/Core/Runtime/Variables/AtomVariable.cs
@@ -160,7 +160,9 @@ namespace UnityAtoms
             // Therefore, there might still be null instances, but even though not ideal,
             // it should not cause any problems.
             // More info: https://issuetracker.unity3d.com/issues/ondisable-and-ondestroy-methods-are-not-called-when-a-scriptableobject-is-deleted-manually-in-project-window 
+#if UNITY_EDITOR
             _instances.Remove(this);
+#endif
         }
 
         /// <summary>


### PR DESCRIPTION
This PR adds appropriate `UNITY_EDITOR` compiler flags in order to solve the error: 
`The name '_instances' does not exist in the current context`