### PR TITLE
[Generator] Fix invalid dependency warning

### DIFF
--- a/Packages/Core/Editor/Generator/GeneratorEditor.cs
+++ b/Packages/Core/Editor/Generator/GeneratorEditor.cs
@@ -97,7 +97,7 @@ namespace UnityAtoms.Editor
         {
             if (disabledDeps != null && disabledDeps.Count > 0)
             {
-                string warningText = $"{String.Join(", ", disabledDeps.Select((a) => a.Name))} depend(s) on {atomType.Name}.";
+                string warningText = $"{String.Join(", ", disabledDeps.Select((a) => a.DisplayName))} depend(s) on {atomType.DisplayName}.";
                 _typesToGenerateInfoRow.Query<Label>().First().text = warningText;
             }
             else


### PR DESCRIPTION
With 4.4.8, removing, for example, `Pair` from Generator, would produce this warning:
![image](https://github.com/unity-atoms/unity-atoms/assets/1030080/f9231109-9109-4315-8831-ed7491d5275d)

Saying that, for example, `Event Instancer` depends on `Pair`, implying it got disabled, but it actually wasn't. It was `Pair Event Instancer` that got disabled, but was messaged incorrectly.

With this PR, that is fixed to:
![image](https://github.com/unity-atoms/unity-atoms/assets/1030080/92117dbe-eb95-44b2-a2fb-0897a6224d18)

To properly indicate what is being disabled.