### PR TITLE
Removed stopping play mode in SceneField:Validate()

### DIFF
--- a/Packages/SceneMgmt/Runtime/Types/SceneField.cs
+++ b/Packages/SceneMgmt/Runtime/Types/SceneField.cs
@@ -87,12 +87,6 @@ namespace UnityAtoms.SceneMgmt
             {
                 /* Sadly its not easy to find which gameobject/component has this SceneField, at least not at this point */
                 Debug.LogError($"A scene [{_sceneName}] you used as reference has no valid build Index", _sceneAsset);
-                // Exit play mode - might be a bit too harsh?
-#if UNITY_2019_1_OR_NEWER
-                EditorApplication.ExitPlaymode();
-#else
-                EditorApplication.isPlaying = false;
-#endif
             }
 #endif
         }


### PR DESCRIPTION
There is no need to stop the play mode, because there are scenes from Addressables that do not have their own build index.

_and in general it is not convenient, there is enough error~_