### PR TITLE
Reduced debug overhead of Events

### DIFF
--- a/Packages/Core/Runtime/Preferences/AtomsPreferences.cs
+++ b/Packages/Core/Runtime/Preferences/AtomsPreferences.cs
@@ -24,24 +24,31 @@ namespace UnityAtoms
 
         public class BoolPreference : Preference<bool>
         {
+            private bool? _cached = null;
             public override bool Get()
             {
+                if (_cached != null) return _cached.Value;
+                
                 if (!EditorPrefs.HasKey(Key))
                 {
                     EditorPrefs.SetBool(Key, DefaultValue);
+                    _cached = DefaultValue;
+                    return _cached.Value;
                 }
 
-                return EditorPrefs.GetBool(Key);
+                _cached = EditorPrefs.GetBool(Key);
+                return _cached.Value;
             }
 
             public override void Set(bool value)
             {
+                _cached = value;
                 EditorPrefs.SetBool(Key, value);
             }
         }
 
         public static bool IsDebugModeEnabled { get => DEBUG_MODE_PREF.Get(); }
-
+        
         private static BoolPreference DEBUG_MODE_PREF = new BoolPreference() { DefaultValue = false, Key = "UnityAtoms.DebugMode" };
 
 #if UNITY_2019_1_OR_NEWER

--- a/Packages/Core/Runtime/StackTrace/StackTraceEntry.cs
+++ b/Packages/Core/Runtime/StackTrace/StackTraceEntry.cs
@@ -61,10 +61,14 @@ namespace UnityAtoms
         }
 
 #if UNITY_EDITOR
+        
+        public static StackTraceEntry Create<T>(T obj, int skipFrames = 0) => AtomPreferences.IsDebugModeEnabled ? new StackTraceEntry(new StackTrace(skipFrames), obj) : null;
         public static StackTraceEntry Create(object obj, int skipFrames = 0) => AtomPreferences.IsDebugModeEnabled ? new StackTraceEntry(new StackTrace(skipFrames), obj) : null;
-
         public static StackTraceEntry Create(int skipFrames = 0) => AtomPreferences.IsDebugModeEnabled ? new StackTraceEntry(new StackTrace(skipFrames)) : null;
+        
 #else
+        public static StackTraceEntry Create<T>(T obj, int skipFrames = 0) => null;
+
         public static StackTraceEntry Create(object obj, int skipFrames = 0) => null;
 
         public static StackTraceEntry Create(int skipFrames = 0) => null;

--- a/Packages/Core/Runtime/StackTrace/StackTraceEntry.cs
+++ b/Packages/Core/Runtime/StackTrace/StackTraceEntry.cs
@@ -63,14 +63,10 @@ namespace UnityAtoms
 #if UNITY_EDITOR
         
         public static StackTraceEntry Create<T>(T obj, int skipFrames = 0) => AtomPreferences.IsDebugModeEnabled ? new StackTraceEntry(new StackTrace(skipFrames), obj) : null;
-        public static StackTraceEntry Create(object obj, int skipFrames = 0) => AtomPreferences.IsDebugModeEnabled ? new StackTraceEntry(new StackTrace(skipFrames), obj) : null;
         public static StackTraceEntry Create(int skipFrames = 0) => AtomPreferences.IsDebugModeEnabled ? new StackTraceEntry(new StackTrace(skipFrames)) : null;
         
 #else
         public static StackTraceEntry Create<T>(T obj, int skipFrames = 0) => null;
-
-        public static StackTraceEntry Create(object obj, int skipFrames = 0) => null;
-
         public static StackTraceEntry Create(int skipFrames = 0) => null;
 #endif
 

--- a/Packages/Core/Runtime/StackTrace/StackTraces.cs
+++ b/Packages/Core/Runtime/StackTrace/StackTraces.cs
@@ -11,6 +11,7 @@ namespace UnityAtoms
 
         public static void AddStackTrace(int id, StackTraceEntry stackTrace)
         {
+            if(stackTrace == null) return;
             if (AtomPreferences.IsDebugModeEnabled)
             {
                 GetStackTraces(id).Insert(0, stackTrace);

--- a/Packages/Core/Runtime/StackTrace/StackTraces.cs
+++ b/Packages/Core/Runtime/StackTrace/StackTraces.cs
@@ -11,7 +11,7 @@ namespace UnityAtoms
 
         public static void AddStackTrace(int id, StackTraceEntry stackTrace)
         {
-            if(stackTrace == null) return;
+            if (stackTrace == null) return;
             if (AtomPreferences.IsDebugModeEnabled)
             {
                 GetStackTraces(id).Insert(0, stackTrace);


### PR DESCRIPTION
fixes: #434 

fix: memory allocations due to boxing when creating a StackTraceEntry with disabled DebugMode.
fix: slow repeaded lookups of EditorPrefs for determining DebugMode