### PR TITLE
Fixing a Rendering issue of QuaternionReferenceDrawer

### DIFF
--- a/Packages/Core/Editor/Drawers/AtomBaseReferenceDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomBaseReferenceDrawer.cs
@@ -82,7 +82,14 @@ namespace UnityAtoms.Editor
             {
                 var expanded = usageTypeProperty.isExpanded;
                 usageTypeProperty.isExpanded = true;
-                var valueFieldHeight = EditorGUI.GetPropertyHeight(usageTypeProperty, label);
+                var valueFieldHeight = usageTypeProperty.propertyType switch
+                {
+                    // In versions prior to 2022.3 GetPropertyHeight returns the wrong value for "SerializedPropertyType.Quaternion"
+                    // In later versions, the fix is introduced _but only_ when using the SerializedPropertyType parameter, not when using the SerializedProperty parameter version.
+                    // ALSO the SerializedPropertyType parameter version does not work with the isExpanded flag which we set to true exactly for this reason a (few) lines above.
+                    SerializedPropertyType.Quaternion => EditorGUI.GetPropertyHeight(SerializedPropertyType.Vector3, label),
+                    _ => EditorGUI.GetPropertyHeight(usageTypeProperty, label),
+                };
                 usageTypeProperty.isExpanded = expanded;
 
                 if (usageTypePropertyName == "_value" && (valueFieldHeight > EditorGUIUtility.singleLineHeight + 2))


### PR DESCRIPTION
due to an unity bug with the result of GetPropertyHeight for Quaternion properties we need to handle Quaternions as special cases

Commit-Type: Bugfix
Resolves: #436 


| 2021.3 | 2022.2.16+ |
| --- | --- |
| ![image](https://github.com/unity-atoms/unity-atoms/assets/3066582/412b83ba-991f-429b-979c-0cb1ca1fe046) | ![image](https://github.com/unity-atoms/unity-atoms/assets/3066582/64192db2-c0d1-4d6a-bba6-2dbef6dc4980) |