### PR TITLE
Auto DragAndDrop UsageTypeDetection

### DIFF
--- a/Packages/BaseAtoms/Editor/Drawers/Collections/AtomCollectionReferenceDrawer.cs
+++ b/Packages/BaseAtoms/Editor/Drawers/Collections/AtomCollectionReferenceDrawer.cs
@@ -7,7 +7,7 @@ namespace UnityAtoms.BaseAtoms.Editor
     /// A custom property drawer for AtomCollectionReference. Makes it possible to choose between a Collection or a Collection Instancer.
     /// </summary>
     [CustomPropertyDrawer(typeof(AtomCollectionReference), true)]
-    public class AtomCollectionReferenceDrawer : AtomBaseReferenceDrawer
+    public class AtomCollectionReferenceDrawer : AtomBaseReferenceDrawer<AtomCollectionInstancer>
     {
         protected class UsageCollection : UsageData
         {

--- a/Packages/BaseAtoms/Editor/Drawers/Collections/AtomListReferenceDrawer.cs
+++ b/Packages/BaseAtoms/Editor/Drawers/Collections/AtomListReferenceDrawer.cs
@@ -7,7 +7,7 @@ namespace UnityAtoms.BaseAtoms.Editor
     /// A custom property drawer for AtomListReference. Makes it possible to choose between a List or a List Instancer.
     /// </summary>
     [CustomPropertyDrawer(typeof(AtomListReference), true)]
-    public class AtomListReferenceDrawer : AtomBaseReferenceDrawer
+    public class AtomListReferenceDrawer : AtomBaseReferenceDrawer<AtomListInstancer>
     {
         protected class UsageList : UsageData
         {

--- a/Packages/BaseAtoms/Editor/Drawers/EventReference/AtomBaseVariableBaseEventReferenceDrawer.cs
+++ b/Packages/BaseAtoms/Editor/Drawers/EventReference/AtomBaseVariableBaseEventReferenceDrawer.cs
@@ -7,7 +7,7 @@ namespace UnityAtoms.BaseAtoms.Editor
     /// A custom property drawer for AtomBaseVariable BaseEventReferences. Makes it possible to choose between an Event, Event Instancer, Collection Added, Collection Removed, List Added, List Removed, Collection Instancer Added, Collection Instancer Removed, List Instancer Added or List Instancer Removed.
     /// </summary>
     [CustomPropertyDrawer(typeof(AtomBaseVariableBaseEventReference), true)]
-    public class AtomBaseVariableBaseEventReferenceDrawer : AtomBaseReferenceDrawer
+    public class AtomBaseVariableBaseEventReferenceDrawer : AtomBaseReferenceDrawer<AtomBaseVariableEventInstancer>
     {
         protected class UsageEvent : UsageData
         {

--- a/Packages/BaseAtoms/Editor/Drawers/EventReference/VoidBaseEventReferenceDrawer.cs
+++ b/Packages/BaseAtoms/Editor/Drawers/EventReference/VoidBaseEventReferenceDrawer.cs
@@ -7,7 +7,7 @@ namespace UnityAtoms.BaseAtoms.Editor
     /// A custom property drawer for Void BaseEventReferences. Makes it possible to choose between an Event, Event Instancer, Collection Cleared, List Cleared, Collection Instancer Cleared or List Instancer Cleared.
     /// </summary>
     [CustomPropertyDrawer(typeof(VoidBaseEventReference), true)]
-    public class VoidBaseEventReferenceDrawer : AtomBaseReferenceDrawer
+    public class VoidBaseEventReferenceDrawer : AtomBaseReferenceDrawer<VoidEventInstancer>
     {
         protected class UsageEvent : UsageData
         {

--- a/Packages/Core/Editor/Drawers/AtomEventReferenceDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomEventReferenceDrawer.cs
@@ -6,7 +6,7 @@ namespace UnityAtoms.Editor
     /// A custom property drawer for Event References. Makes it possible to choose between an Event, Event Instancer, Variable or a Variable Instancer.
     /// </summary>
     [CustomPropertyDrawer(typeof(AtomBaseEventReference), true)]
-    public class AtomEventReferenceDrawer : AtomBaseReferenceDrawer
+    public class AtomEventReferenceDrawer : AtomBaseReferenceDrawer<AtomEventInstancer>
     {
         protected class UsageEvent : UsageData
         {

--- a/Packages/Core/Editor/Drawers/AtomReferenceDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomReferenceDrawer.cs
@@ -7,7 +7,7 @@ namespace UnityAtoms.Editor
     /// </summary>
 
     [CustomPropertyDrawer(typeof(AtomBaseReference), true)]
-    public class AtomReferenceDrawer : AtomBaseReferenceDrawer
+    public class AtomReferenceDrawer : AtomBaseReferenceDrawer<AtomBaseVariableInstancer>
     {
         protected class UsageValue : UsageData
         {

--- a/Packages/Core/Runtime/EventInstancers/AtomEventInstancer.cs
+++ b/Packages/Core/Runtime/EventInstancers/AtomEventInstancer.cs
@@ -5,6 +5,11 @@ using UnityEngine.Assertions;
 namespace UnityAtoms
 {
 
+    public abstract class AtomEventInstancer : MonoBehaviour
+    {
+        
+    }
+    
     /// <summary>
     /// An Event Instancer is a MonoBehaviour that takes an Event as a base and creates an in memory copy of it on OnEnable.
     /// This is handy when you want to use Events for prefabs that are instantiated at runtime. 
@@ -13,7 +18,7 @@ namespace UnityAtoms
     /// <typeparam name="E">Event of type T.</typeparam>
     [EditorIcon("atom-icon-sign-blue")]
     [DefaultExecutionOrder(Runtime.ExecutionOrder.VARIABLE_INSTANCER)]
-    public abstract class AtomEventInstancer<T, E> : MonoBehaviour, IGetEvent, ISetEvent
+    public abstract class AtomEventInstancer<T, E> : AtomEventInstancer, IGetEvent, ISetEvent
         where E : AtomEvent<T>
     {
         public T InspectorRaiseValue { get => _inspectorRaiseValue; }

--- a/Packages/Core/Runtime/VariableInstancers/AtomBaseVariableInstancer.cs
+++ b/Packages/Core/Runtime/VariableInstancers/AtomBaseVariableInstancer.cs
@@ -30,22 +30,6 @@ namespace UnityAtoms
         /// </summary>
         public V Variable { get => _inMemoryCopy; }
 
-        public void SetSource(V variable)
-        {
-            _base = variable;
-            if (Application.isPlaying)
-            {
-                Debug.LogWarning("Setting the underlying variable of an instancers at runtime can result in hard to find issues. be careful.");
-                if (_inMemoryCopy != null)
-                {
-                    Destroy(_inMemoryCopy);
-                    _inMemoryCopy = null;
-                }
-                OnEnable();
-            }
-            
-        }
-        
         /// <summary>
         /// Getter for retrieving the value of the in memory runtime variable.
         /// </summary>

--- a/Packages/Core/Runtime/VariableInstancers/AtomBaseVariableInstancer.cs
+++ b/Packages/Core/Runtime/VariableInstancers/AtomBaseVariableInstancer.cs
@@ -4,6 +4,11 @@ using UnityEngine.Assertions;
 
 namespace UnityAtoms
 {
+    public abstract class AtomBaseVariableInstancer : MonoBehaviour
+    {
+        
+    }
+    
     /// <summary>
     /// A Variable Instancer is a MonoBehaviour that takes a variable as a base and creates an in memory copy of it OnEnable.
     /// This is handy when you want to use atoms for prefabs that are instantiated at runtime. Use together with AtomCollection to
@@ -17,7 +22,7 @@ namespace UnityAtoms
     /// <typeparam name="F">Function of type T => T</typeparam>
     [EditorIcon("atom-icon-hotpink")]
     [DefaultExecutionOrder(Runtime.ExecutionOrder.VARIABLE_INSTANCER)]
-    public abstract class AtomBaseVariableInstancer<T, V> : MonoBehaviour, IVariable<V>
+    public abstract class AtomBaseVariableInstancer<T, V> : AtomBaseVariableInstancer, IVariable<V>
         where V : AtomBaseVariable<T>
     {
         /// <summary>
@@ -25,6 +30,22 @@ namespace UnityAtoms
         /// </summary>
         public V Variable { get => _inMemoryCopy; }
 
+        public void SetSource(V variable)
+        {
+            _base = variable;
+            if (Application.isPlaying)
+            {
+                Debug.LogWarning("Setting the underlying variable of an instancers at runtime can result in hard to find issues. be careful.");
+                if (_inMemoryCopy != null)
+                {
+                    Destroy(_inMemoryCopy);
+                    _inMemoryCopy = null;
+                }
+                OnEnable();
+            }
+            
+        }
+        
         /// <summary>
         /// Getter for retrieving the value of the in memory runtime variable.
         /// </summary>

--- a/Packages/FSM/Editor/Drawers/FiniteStateMachineReferenceDrawer.cs
+++ b/Packages/FSM/Editor/Drawers/FiniteStateMachineReferenceDrawer.cs
@@ -7,7 +7,7 @@ namespace UnityAtoms.FSM.Editor
     /// A custom property drawer for FiniteStateMachineReference. Makes it possible to choose between a FSM or a FSM Instancer.
     /// </summary>
     [CustomPropertyDrawer(typeof(FiniteStateMachineReference), true)]
-    public class FiniteStateMachineReferenceDrawer : AtomBaseReferenceDrawer
+    public class FiniteStateMachineReferenceDrawer : AtomBaseReferenceDrawer<FiniteStateMachineInstancer>
     {
         protected class UsageFSM : UsageData
         {


### PR DESCRIPTION
implements "Auto DragAndDrop UsageTypeDetection" for reference fields based on PR from @toasterhead-master

    - contains only changes regarding to the feature itself without any of the refactoring
    - reduces the amount of boilerplate classes

Closes: #441

________________________

This PR is obviously in conflict with #440. It contains the feature related parts of the 440 without any of the refactoring, also this is now independent of #436 and can be reviewed in isolation and both should be free from merge conflicts regardless of order.

Also this version does not contain any of the helper classes "GuiData" or "UsageIndex", since they are not necessary at all (opinion)

Also this version implements the Auto DragAndDrop UsageTypeDetection for all of the 8 sub-classes of the reference drawer.