### PR TITLE
#443 [FEATURE] AtomBaseEventReference to have Raise methods inside

### DIFF
--- a/Packages/Core/Runtime/EventReferences/AtomBaseEventReference.cs
+++ b/Packages/Core/Runtime/EventReferences/AtomBaseEventReference.cs
@@ -24,6 +24,8 @@ namespace UnityAtoms
         /// </summary>
         [SerializeField]
         protected int _usage;
+
+        public abstract void Raise();
     }
 
     /// <summary>
@@ -65,6 +67,26 @@ namespace UnityAtoms
                         throw new NotSupportedException($"Event not reassignable for usage {_usage}.");
                 }
             }
+        }
+
+        public override void Raise()
+        {
+            var eventRef = Event;
+
+            if (eventRef)
+                eventRef.Raise();
+            else
+                Debug.LogError("Event is null");
+        }
+        
+        public void Raise(T value)
+        {
+            var eventRef = Event;
+
+            if (eventRef)
+                eventRef.Raise(value);
+            else
+                Debug.LogError("Event is null");
         }
 
         /// <summary>


### PR DESCRIPTION
Closes: #443
- Also instead of raising an exception we just `Debug.LogError` whenever the `Event` is null to not disturb any code that is followed by the event call. The question of whether or not to raise an exception is talked about in a [discord channel](https://discord.com/channels/640589221136171020/643165315546742785/1168946487783329921)