### PR TITLE
Fix value field height in reference drawer for older Unity versions

### DIFF
--- a/Packages/Core/Editor/Drawers/AtomBaseReferenceDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomBaseReferenceDrawer.cs
@@ -79,7 +79,14 @@ namespace UnityAtoms.Editor
 
             var innerProperty = property.FindPropertyRelative(usageData.PropertyName);
 
-            return innerProperty == null ?
+            bool forceSingleLine = false;
+#if UNITY_2021_2_OR_NEWER
+            // This is needed for similar reasons as described in the comment in the DrawField method below.
+            // This is basically a hack to fix a bug on Unity's side, which we need to revert when / if Unity fix it on their side.
+            forceSingleLine = innerProperty != null && innerProperty.propertyType == SerializedPropertyType.Quaternion;
+#endif
+
+            return innerProperty == null || forceSingleLine ?
                 EditorGUIUtility.singleLineHeight :
                 EditorGUI.GetPropertyHeight(innerProperty, label);
         }

--- a/Packages/Core/Editor/Drawers/AtomBaseReferenceDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomBaseReferenceDrawer.cs
@@ -109,12 +109,16 @@ namespace UnityAtoms.Editor
             {
                 var expanded = usageTypeProperty.isExpanded;
                 usageTypeProperty.isExpanded = true;
+#if UNITY_2021_2_OR_NEWER
                 var valueFieldHeight = usageTypeProperty.propertyType == SerializedPropertyType.Quaternion ?
                     // In versions prior to 2022.3 GetPropertyHeight returns the wrong value for "SerializedPropertyType.Quaternion"
                     // In later versions, the fix is introduced _but only_ when using the SerializedPropertyType parameter, not when using the SerializedProperty parameter version.
                     // ALSO the SerializedPropertyType parameter version does not work with the isExpanded flag which we set to true exactly for this reason a (few) lines above.
                     EditorGUI.GetPropertyHeight(SerializedPropertyType.Vector3, guiData.Label) :
                     EditorGUI.GetPropertyHeight(usageTypeProperty, guiData.Label);
+#else
+                var valueFieldHeight = EditorGUI.GetPropertyHeight(usageTypeProperty, guiData.Label);
+#endif
 
                 usageTypeProperty.isExpanded = expanded;
 

--- a/Packages/Core/Editor/Editors/Variables/AtomVariableEditor.cs
+++ b/Packages/Core/Editor/Editors/Variables/AtomVariableEditor.cs
@@ -25,7 +25,7 @@ namespace UnityAtoms.Editor
             }
             else
             {
-                // Quaternion property height is not handled correctly by Unity in versions
+                // Quaternion property height is not handled correctly by Unity in version
                 // 2021.2 and above. Taking that into account here.
 #if UNITY_2021_2_OR_NEWER
                 if (property.propertyType == SerializedPropertyType.Quaternion)

--- a/Packages/Core/Editor/Editors/Variables/AtomVariableEditor.cs
+++ b/Packages/Core/Editor/Editors/Variables/AtomVariableEditor.cs
@@ -25,7 +25,18 @@ namespace UnityAtoms.Editor
             }
             else
             {
-                EditorGUILayout.PropertyField(property, true);
+                // Quaternion property height is not handled correctly by Unity in versions
+                // 2021.2 and above. Taking that into account here.
+#if UNITY_2021_2_OR_NEWER
+                if (property.propertyType == SerializedPropertyType.Quaternion)
+                {
+                    EditorGUILayout.PropertyField(property, false);
+                }
+                else
+#endif
+                {
+                    EditorGUILayout.PropertyField(property, true);
+                }
             }
         }
 


### PR DESCRIPTION
Reverts the changes in #440 / #437 for older Unity versions (2022.1 or older) since it breaks the drawer in those versions. 

**Before change (2021.1.6f1)**
![Skärmavbild 2023-12-18 kl  23 20 37](https://github.com/unity-atoms/unity-atoms/assets/10260896/31e2a916-0d2c-4ef4-931f-39d64200e134)

**After change (2021.1.6f1)**
![Skärmavbild 2023-12-18 kl  23 19 57](https://github.com/unity-atoms/unity-atoms/assets/10260896/41e808dd-e066-49be-94c9-a7dfc3c26caf)
