### PR TITLE
Handling physics disabled

### DIFF
--- a/Packages/BaseAtoms/Editor/Drawers/Constants/Collider2DConstantDrawer.cs
+++ b/Packages/BaseAtoms/Editor/Drawers/Constants/Collider2DConstantDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/BaseAtoms/Editor/Drawers/Constants/ColliderConstantDrawer.cs
+++ b/Packages/BaseAtoms/Editor/Drawers/Constants/ColliderConstantDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/BaseAtoms/Editor/Drawers/Constants/Collision2DConstantDrawer.cs
+++ b/Packages/BaseAtoms/Editor/Drawers/Constants/Collision2DConstantDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/BaseAtoms/Editor/Drawers/Constants/CollisionConstantDrawer.cs
+++ b/Packages/BaseAtoms/Editor/Drawers/Constants/CollisionConstantDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/BaseAtoms/Editor/Drawers/Events/Collider2DEventDrawer.cs
+++ b/Packages/BaseAtoms/Editor/Drawers/Events/Collider2DEventDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/BaseAtoms/Editor/Drawers/Events/Collider2DPairEventDrawer.cs
+++ b/Packages/BaseAtoms/Editor/Drawers/Events/Collider2DPairEventDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/BaseAtoms/Editor/Drawers/Events/ColliderEventDrawer.cs
+++ b/Packages/BaseAtoms/Editor/Drawers/Events/ColliderEventDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/BaseAtoms/Editor/Drawers/Events/ColliderPairEventDrawer.cs
+++ b/Packages/BaseAtoms/Editor/Drawers/Events/ColliderPairEventDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/BaseAtoms/Editor/Drawers/Events/Collision2DEventDrawer.cs
+++ b/Packages/BaseAtoms/Editor/Drawers/Events/Collision2DEventDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/BaseAtoms/Editor/Drawers/Events/Collision2DPairEventDrawer.cs
+++ b/Packages/BaseAtoms/Editor/Drawers/Events/Collision2DPairEventDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/BaseAtoms/Editor/Drawers/Events/CollisionEventDrawer.cs
+++ b/Packages/BaseAtoms/Editor/Drawers/Events/CollisionEventDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/BaseAtoms/Editor/Drawers/Events/CollisionPairEventDrawer.cs
+++ b/Packages/BaseAtoms/Editor/Drawers/Events/CollisionPairEventDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/BaseAtoms/Editor/Drawers/ValueLists/Collider2DValueListDrawer.cs
+++ b/Packages/BaseAtoms/Editor/Drawers/ValueLists/Collider2DValueListDrawer.cs
@@ -1,6 +1,6 @@
-#if UNITY_2019_1_OR_NEWER
-using UnityEditor;
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS2D
 using UnityAtoms.Editor;
+using UnityEditor;
 
 namespace UnityAtoms.BaseAtoms.Editor
 {

--- a/Packages/BaseAtoms/Editor/Drawers/ValueLists/ColliderValueListDrawer.cs
+++ b/Packages/BaseAtoms/Editor/Drawers/ValueLists/ColliderValueListDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/BaseAtoms/Editor/Drawers/ValueLists/Collision2DValueListDrawer.cs
+++ b/Packages/BaseAtoms/Editor/Drawers/ValueLists/Collision2DValueListDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/BaseAtoms/Editor/Drawers/ValueLists/CollisionValueListDrawer.cs
+++ b/Packages/BaseAtoms/Editor/Drawers/ValueLists/CollisionValueListDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/BaseAtoms/Editor/Drawers/Variables/Collider2DVariableDrawer.cs
+++ b/Packages/BaseAtoms/Editor/Drawers/Variables/Collider2DVariableDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/BaseAtoms/Editor/Drawers/Variables/ColliderVariableDrawer.cs
+++ b/Packages/BaseAtoms/Editor/Drawers/Variables/ColliderVariableDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/BaseAtoms/Editor/Drawers/Variables/Collision2DVariableDrawer.cs
+++ b/Packages/BaseAtoms/Editor/Drawers/Variables/Collision2DVariableDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/BaseAtoms/Editor/Drawers/Variables/CollisionVariableDrawer.cs
+++ b/Packages/BaseAtoms/Editor/Drawers/Variables/CollisionVariableDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/BaseAtoms/Editor/Editors/EventInstancers/Collider2DEventInstancerEditor.cs
+++ b/Packages/BaseAtoms/Editor/Editors/EventInstancers/Collider2DEventInstancerEditor.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityEngine.UIElements;
 using UnityAtoms.Editor;

--- a/Packages/BaseAtoms/Editor/Editors/EventInstancers/ColliderEventInstancerEditor.cs
+++ b/Packages/BaseAtoms/Editor/Editors/EventInstancers/ColliderEventInstancerEditor.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityEngine.UIElements;
 using UnityAtoms.Editor;

--- a/Packages/BaseAtoms/Editor/Editors/Events/Collider2DEventEditor.cs
+++ b/Packages/BaseAtoms/Editor/Editors/Events/Collider2DEventEditor.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityEngine.UIElements;
 using UnityAtoms.Editor;

--- a/Packages/BaseAtoms/Editor/Editors/Events/Collider2DPairEventEditor.cs
+++ b/Packages/BaseAtoms/Editor/Editors/Events/Collider2DPairEventEditor.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityEngine.UIElements;
 using UnityAtoms.Editor;

--- a/Packages/BaseAtoms/Editor/Editors/Events/ColliderEventEditor.cs
+++ b/Packages/BaseAtoms/Editor/Editors/Events/ColliderEventEditor.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityEngine.UIElements;
 using UnityAtoms.Editor;

--- a/Packages/BaseAtoms/Editor/Editors/Events/ColliderPairEventEditor.cs
+++ b/Packages/BaseAtoms/Editor/Editors/Events/ColliderPairEventEditor.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityEngine.UIElements;
 using UnityAtoms.Editor;

--- a/Packages/BaseAtoms/Editor/Editors/Events/Collision2DEventEditor.cs
+++ b/Packages/BaseAtoms/Editor/Editors/Events/Collision2DEventEditor.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityEngine.UIElements;
 using UnityAtoms.Editor;

--- a/Packages/BaseAtoms/Editor/Editors/Events/Collision2DPairEventEditor.cs
+++ b/Packages/BaseAtoms/Editor/Editors/Events/Collision2DPairEventEditor.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityEngine.UIElements;
 using UnityAtoms.Editor;

--- a/Packages/BaseAtoms/Editor/Editors/Events/CollisionEventEditor.cs
+++ b/Packages/BaseAtoms/Editor/Editors/Events/CollisionEventEditor.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityEngine.UIElements;
 using UnityAtoms.Editor;

--- a/Packages/BaseAtoms/Editor/Editors/Events/CollisionPairEventEditor.cs
+++ b/Packages/BaseAtoms/Editor/Editors/Events/CollisionPairEventEditor.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityEngine.UIElements;
 using UnityAtoms.Editor;

--- a/Packages/BaseAtoms/Editor/Editors/Variables/Collider2DVariableEditor.cs
+++ b/Packages/BaseAtoms/Editor/Editors/Variables/Collider2DVariableEditor.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityAtoms.Editor;
 using UnityEngine;
@@ -10,3 +11,4 @@ namespace UnityAtoms.BaseAtoms.Editor
     [CustomEditor(typeof(Collider2DVariable))]
     public sealed class Collider2DVariableEditor : AtomVariableEditor<Collider2D, Collider2DPair> { }
 }
+#endif

--- a/Packages/BaseAtoms/Editor/Editors/Variables/ColliderVariableEditor.cs
+++ b/Packages/BaseAtoms/Editor/Editors/Variables/ColliderVariableEditor.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityAtoms.Editor;
 using UnityEngine;
@@ -10,3 +11,4 @@ namespace UnityAtoms.BaseAtoms.Editor
     [CustomEditor(typeof(ColliderVariable))]
     public sealed class ColliderVariableEditor : AtomVariableEditor<Collider, ColliderPair> { }
 }
+#endif

--- a/Packages/BaseAtoms/Editor/Editors/Variables/Collision2DVariableEditor.cs
+++ b/Packages/BaseAtoms/Editor/Editors/Variables/Collision2DVariableEditor.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityAtoms.Editor;
 using UnityEngine;
@@ -10,3 +11,4 @@ namespace UnityAtoms.BaseAtoms.Editor
     [CustomEditor(typeof(Collision2DVariable))]
     public sealed class Collision2DVariableEditor : AtomVariableEditor<Collision2D, Collision2DPair> { }
 }
+#endif

--- a/Packages/BaseAtoms/Editor/Editors/Variables/CollisionVariableEditor.cs
+++ b/Packages/BaseAtoms/Editor/Editors/Variables/CollisionVariableEditor.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityAtoms.Editor;
 using UnityEngine;
@@ -10,3 +11,4 @@ namespace UnityAtoms.BaseAtoms.Editor
     [CustomEditor(typeof(CollisionVariable))]
     public sealed class CollisionVariableEditor : AtomVariableEditor<Collision, CollisionPair> { }
 }
+#endif

--- a/Packages/BaseAtoms/Editor/UnityAtoms.UnityAtomsBaseAtoms.Editor.asmdef
+++ b/Packages/BaseAtoms/Editor/UnityAtoms.UnityAtomsBaseAtoms.Editor.asmdef
@@ -14,6 +14,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.modules.physics",
+            "expression": "0.0.0",
+            "define": "PACKAGE_UNITY_PHYSICS"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Packages/BaseAtoms/Editor/UnityAtoms.UnityAtomsBaseAtoms.Editor.asmdef
+++ b/Packages/BaseAtoms/Editor/UnityAtoms.UnityAtomsBaseAtoms.Editor.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "UnityAtoms.UnityAtomsBaseAtoms.Editor",
+    "rootNamespace": "",
     "references": [
         "UnityAtoms.UnityAtomsCore.Runtime",
         "UnityAtoms.UnityAtomsCore.Editor",
@@ -19,6 +20,11 @@
             "name": "com.unity.modules.physics",
             "expression": "0.0.0",
             "define": "PACKAGE_UNITY_PHYSICS"
+        },
+        {
+            "name": "com.unity.modules.physics2d",
+            "expression": "0.0.0",
+            "define": "PACKAGE_UNITY_PHYSICS2D"
         }
     ],
     "noEngineReferences": false

--- a/Packages/BaseAtoms/Runtime/Actions/Collider2DAction.cs
+++ b/Packages/BaseAtoms/Runtime/Actions/Collider2DAction.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 namespace UnityAtoms.BaseAtoms
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.BaseAtoms
     [EditorIcon("atom-icon-purple")]
     public abstract class Collider2DAction : AtomAction<Collider2D> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Actions/Collider2DPairAction.cs
+++ b/Packages/BaseAtoms/Runtime/Actions/Collider2DPairAction.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 namespace UnityAtoms.BaseAtoms
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.BaseAtoms
     [EditorIcon("atom-icon-purple")]
     public abstract class Collider2DPairAction : AtomAction<Collider2DPair> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Actions/ColliderAction.cs
+++ b/Packages/BaseAtoms/Runtime/Actions/ColliderAction.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 namespace UnityAtoms.BaseAtoms
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.BaseAtoms
     [EditorIcon("atom-icon-purple")]
     public abstract class ColliderAction : AtomAction<Collider> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Actions/ColliderPairAction.cs
+++ b/Packages/BaseAtoms/Runtime/Actions/ColliderPairAction.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 namespace UnityAtoms.BaseAtoms
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.BaseAtoms
     [EditorIcon("atom-icon-purple")]
     public abstract class ColliderPairAction : AtomAction<ColliderPair> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Actions/Collision2DAction.cs
+++ b/Packages/BaseAtoms/Runtime/Actions/Collision2DAction.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 namespace UnityAtoms.BaseAtoms
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.BaseAtoms
     [EditorIcon("atom-icon-purple")]
     public abstract class Collision2DAction : AtomAction<Collision2D> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Actions/Collision2DPairAction.cs
+++ b/Packages/BaseAtoms/Runtime/Actions/Collision2DPairAction.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 namespace UnityAtoms.BaseAtoms
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.BaseAtoms
     [EditorIcon("atom-icon-purple")]
     public abstract class Collision2DPairAction : AtomAction<Collision2DPair> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Actions/CollisionAction.cs
+++ b/Packages/BaseAtoms/Runtime/Actions/CollisionAction.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 namespace UnityAtoms.BaseAtoms
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.BaseAtoms
     [EditorIcon("atom-icon-purple")]
     public abstract class CollisionAction : AtomAction<Collision> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Actions/CollisionPairAction.cs
+++ b/Packages/BaseAtoms/Runtime/Actions/CollisionPairAction.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 namespace UnityAtoms.BaseAtoms
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.BaseAtoms
     [EditorIcon("atom-icon-purple")]
     public abstract class CollisionPairAction : AtomAction<CollisionPair> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Actions/SetVariableValue/SetCollider2DVariableValue.cs
+++ b/Packages/BaseAtoms/Runtime/Actions/SetVariableValue/SetCollider2DVariableValue.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityAtoms.BaseAtoms;
 using UnityEngine;
 
@@ -20,3 +21,4 @@ namespace UnityAtoms.BaseAtoms
         Collider2DVariableInstancer>
     { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Actions/SetVariableValue/SetColliderVariableValue.cs
+++ b/Packages/BaseAtoms/Runtime/Actions/SetVariableValue/SetColliderVariableValue.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityAtoms.BaseAtoms;
 using UnityEngine;
 
@@ -20,3 +21,4 @@ namespace UnityAtoms.BaseAtoms
         ColliderVariableInstancer>
     { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Actions/SetVariableValue/SetCollision2DVariableValue.cs
+++ b/Packages/BaseAtoms/Runtime/Actions/SetVariableValue/SetCollision2DVariableValue.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityAtoms.BaseAtoms;
 using UnityEngine;
 
@@ -20,3 +21,4 @@ namespace UnityAtoms.BaseAtoms
         Collision2DVariableInstancer>
     { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Actions/SetVariableValue/SetCollisionVariableValue.cs
+++ b/Packages/BaseAtoms/Runtime/Actions/SetVariableValue/SetCollisionVariableValue.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityAtoms.BaseAtoms;
 using UnityEngine;
 
@@ -20,3 +21,4 @@ namespace UnityAtoms.BaseAtoms
         CollisionVariableInstancer>
     { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Conditions/Collider2DCondition.cs
+++ b/Packages/BaseAtoms/Runtime/Conditions/Collider2DCondition.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 namespace UnityAtoms.BaseAtoms
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.BaseAtoms
     [EditorIcon("atom-icon-teal")]
     public abstract class Collider2DCondition : AtomCondition<Collider2D> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Conditions/ColliderCondition.cs
+++ b/Packages/BaseAtoms/Runtime/Conditions/ColliderCondition.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 namespace UnityAtoms.BaseAtoms
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.BaseAtoms
     [EditorIcon("atom-icon-teal")]
     public abstract class ColliderCondition : AtomCondition<Collider> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Conditions/Collision2DCondition.cs
+++ b/Packages/BaseAtoms/Runtime/Conditions/Collision2DCondition.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 namespace UnityAtoms.BaseAtoms
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.BaseAtoms
     [EditorIcon("atom-icon-teal")]
     public abstract class Collision2DCondition : AtomCondition<Collision2D> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Conditions/CollisionCondition.cs
+++ b/Packages/BaseAtoms/Runtime/Conditions/CollisionCondition.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 namespace UnityAtoms.BaseAtoms
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.BaseAtoms
     [EditorIcon("atom-icon-teal")]
     public abstract class CollisionCondition : AtomCondition<Collision> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Constants/Collider2DConstant.cs
+++ b/Packages/BaseAtoms/Runtime/Constants/Collider2DConstant.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -9,3 +10,4 @@ namespace UnityAtoms.BaseAtoms
     [CreateAssetMenu(menuName = "Unity Atoms/Constants/Collider2D", fileName = "Collider2DConstant")]
     public sealed class Collider2DConstant : AtomBaseVariable<Collider2D> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Constants/ColliderConstant.cs
+++ b/Packages/BaseAtoms/Runtime/Constants/ColliderConstant.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -9,3 +10,4 @@ namespace UnityAtoms.BaseAtoms
     [CreateAssetMenu(menuName = "Unity Atoms/Constants/Collider", fileName = "ColliderConstant")]
     public sealed class ColliderConstant : AtomBaseVariable<Collider> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Constants/Collision2DConstant.cs
+++ b/Packages/BaseAtoms/Runtime/Constants/Collision2DConstant.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -9,3 +10,4 @@ namespace UnityAtoms.BaseAtoms
     [CreateAssetMenu(menuName = "Unity Atoms/Constants/Collision2D", fileName = "Collision2DConstant")]
     public sealed class Collision2DConstant : AtomBaseVariable<Collision2D> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Constants/CollisionConstant.cs
+++ b/Packages/BaseAtoms/Runtime/Constants/CollisionConstant.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -9,3 +10,4 @@ namespace UnityAtoms.BaseAtoms
     [CreateAssetMenu(menuName = "Unity Atoms/Constants/Collision", fileName = "CollisionConstant")]
     public sealed class CollisionConstant : AtomBaseVariable<Collision> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/EventInstancers/Collider2DEventInstancer.cs
+++ b/Packages/BaseAtoms/Runtime/EventInstancers/Collider2DEventInstancer.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -9,3 +10,4 @@ namespace UnityAtoms.BaseAtoms
     [AddComponentMenu("Unity Atoms/Event Instancers/Collider2D Event Instancer")]
     public class Collider2DEventInstancer : AtomEventInstancer<Collider2D, Collider2DEvent> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/EventInstancers/Collider2DPairEventInstancer.cs
+++ b/Packages/BaseAtoms/Runtime/EventInstancers/Collider2DPairEventInstancer.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -9,3 +10,4 @@ namespace UnityAtoms.BaseAtoms
     [AddComponentMenu("Unity Atoms/Event Instancers/Collider2DPair Event Instancer")]
     public class Collider2DPairEventInstancer : AtomEventInstancer<Collider2DPair, Collider2DPairEvent> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/EventInstancers/ColliderEventInstancer.cs
+++ b/Packages/BaseAtoms/Runtime/EventInstancers/ColliderEventInstancer.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -9,3 +10,4 @@ namespace UnityAtoms.BaseAtoms
     [AddComponentMenu("Unity Atoms/Event Instancers/Collider Event Instancer")]
     public class ColliderEventInstancer : AtomEventInstancer<Collider, ColliderEvent> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/EventInstancers/ColliderPairEventInstancer.cs
+++ b/Packages/BaseAtoms/Runtime/EventInstancers/ColliderPairEventInstancer.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -9,3 +10,4 @@ namespace UnityAtoms.BaseAtoms
     [AddComponentMenu("Unity Atoms/Event Instancers/ColliderPair Event Instancer")]
     public class ColliderPairEventInstancer : AtomEventInstancer<ColliderPair, ColliderPairEvent> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/EventInstancers/Collision2DEventInstancer.cs
+++ b/Packages/BaseAtoms/Runtime/EventInstancers/Collision2DEventInstancer.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -9,3 +10,4 @@ namespace UnityAtoms.BaseAtoms
     [AddComponentMenu("Unity Atoms/Event Instancers/Collision2D Event Instancer")]
     public class Collision2DEventInstancer : AtomEventInstancer<Collision2D, Collision2DEvent> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/EventInstancers/Collision2DPairEventInstancer.cs
+++ b/Packages/BaseAtoms/Runtime/EventInstancers/Collision2DPairEventInstancer.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -9,3 +10,4 @@ namespace UnityAtoms.BaseAtoms
     [AddComponentMenu("Unity Atoms/Event Instancers/Collision2DPair Event Instancer")]
     public class Collision2DPairEventInstancer : AtomEventInstancer<Collision2DPair, Collision2DPairEvent> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/EventInstancers/CollisionEventInstancer.cs
+++ b/Packages/BaseAtoms/Runtime/EventInstancers/CollisionEventInstancer.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -9,3 +10,4 @@ namespace UnityAtoms.BaseAtoms
     [AddComponentMenu("Unity Atoms/Event Instancers/Collision Event Instancer")]
     public class CollisionEventInstancer : AtomEventInstancer<Collision, CollisionEvent> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/EventInstancers/CollisionPairEventInstancer.cs
+++ b/Packages/BaseAtoms/Runtime/EventInstancers/CollisionPairEventInstancer.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -9,3 +10,4 @@ namespace UnityAtoms.BaseAtoms
     [AddComponentMenu("Unity Atoms/Event Instancers/CollisionPair Event Instancer")]
     public class CollisionPairEventInstancer : AtomEventInstancer<CollisionPair, CollisionPairEvent> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/EventReferenceListeners/Collider2DEventReferenceListener.cs
+++ b/Packages/BaseAtoms/Runtime/EventReferenceListeners/Collider2DEventReferenceListener.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -14,3 +15,4 @@ namespace UnityAtoms.BaseAtoms
         Collider2DUnityEvent>
     { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/EventReferenceListeners/Collider2DPairEventReferenceListener.cs
+++ b/Packages/BaseAtoms/Runtime/EventReferenceListeners/Collider2DPairEventReferenceListener.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -14,3 +15,4 @@ namespace UnityAtoms.BaseAtoms
         Collider2DPairUnityEvent>
     { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/EventReferenceListeners/ColliderEventReferenceListener.cs
+++ b/Packages/BaseAtoms/Runtime/EventReferenceListeners/ColliderEventReferenceListener.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -14,3 +15,4 @@ namespace UnityAtoms.BaseAtoms
         ColliderUnityEvent>
     { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/EventReferenceListeners/ColliderPairEventReferenceListener.cs
+++ b/Packages/BaseAtoms/Runtime/EventReferenceListeners/ColliderPairEventReferenceListener.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -14,3 +15,4 @@ namespace UnityAtoms.BaseAtoms
         ColliderPairUnityEvent>
     { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/EventReferenceListeners/Collision2DEventReferenceListener.cs
+++ b/Packages/BaseAtoms/Runtime/EventReferenceListeners/Collision2DEventReferenceListener.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -14,3 +15,4 @@ namespace UnityAtoms.BaseAtoms
         Collision2DUnityEvent>
     { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/EventReferenceListeners/Collision2DPairEventReferenceListener.cs
+++ b/Packages/BaseAtoms/Runtime/EventReferenceListeners/Collision2DPairEventReferenceListener.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -14,3 +15,4 @@ namespace UnityAtoms.BaseAtoms
         Collision2DPairUnityEvent>
     { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/EventReferenceListeners/CollisionEventReferenceListener.cs
+++ b/Packages/BaseAtoms/Runtime/EventReferenceListeners/CollisionEventReferenceListener.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -14,3 +15,4 @@ namespace UnityAtoms.BaseAtoms
         CollisionUnityEvent>
     { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/EventReferenceListeners/CollisionPairEventReferenceListener.cs
+++ b/Packages/BaseAtoms/Runtime/EventReferenceListeners/CollisionPairEventReferenceListener.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -14,3 +15,4 @@ namespace UnityAtoms.BaseAtoms
         CollisionPairUnityEvent>
     { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/EventReferences/Collider2DEventReference.cs
+++ b/Packages/BaseAtoms/Runtime/EventReferences/Collider2DEventReference.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using System;
 using UnityEngine;
 
@@ -15,3 +16,4 @@ namespace UnityAtoms.BaseAtoms
         Collider2DEventInstancer>, IGetEvent 
     { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/EventReferences/Collider2DPairEventReference.cs
+++ b/Packages/BaseAtoms/Runtime/EventReferences/Collider2DPairEventReference.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using System;
 using UnityEngine;
 
@@ -15,3 +16,4 @@ namespace UnityAtoms.BaseAtoms
         Collider2DPairEventInstancer>, IGetEvent 
     { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/EventReferences/ColliderEventReference.cs
+++ b/Packages/BaseAtoms/Runtime/EventReferences/ColliderEventReference.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using System;
 using UnityEngine;
 
@@ -15,3 +16,4 @@ namespace UnityAtoms.BaseAtoms
         ColliderEventInstancer>, IGetEvent 
     { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/EventReferences/ColliderPairEventReference.cs
+++ b/Packages/BaseAtoms/Runtime/EventReferences/ColliderPairEventReference.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using System;
 using UnityEngine;
 
@@ -15,3 +16,4 @@ namespace UnityAtoms.BaseAtoms
         ColliderPairEventInstancer>, IGetEvent 
     { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/EventReferences/Collision2DEventReference.cs
+++ b/Packages/BaseAtoms/Runtime/EventReferences/Collision2DEventReference.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using System;
 using UnityEngine;
 
@@ -15,3 +16,4 @@ namespace UnityAtoms.BaseAtoms
         Collision2DEventInstancer>, IGetEvent 
     { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/EventReferences/Collision2DPairEventReference.cs
+++ b/Packages/BaseAtoms/Runtime/EventReferences/Collision2DPairEventReference.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using System;
 using UnityEngine;
 
@@ -15,3 +16,4 @@ namespace UnityAtoms.BaseAtoms
         Collision2DPairEventInstancer>, IGetEvent 
     { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/EventReferences/CollisionEventReference.cs
+++ b/Packages/BaseAtoms/Runtime/EventReferences/CollisionEventReference.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using System;
 using UnityEngine;
 
@@ -15,3 +16,4 @@ namespace UnityAtoms.BaseAtoms
         CollisionEventInstancer>, IGetEvent 
     { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/EventReferences/CollisionPairEventReference.cs
+++ b/Packages/BaseAtoms/Runtime/EventReferences/CollisionPairEventReference.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using System;
 using UnityEngine;
 
@@ -15,3 +16,4 @@ namespace UnityAtoms.BaseAtoms
         CollisionPairEventInstancer>, IGetEvent 
     { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Events/Collider2DEvent.cs
+++ b/Packages/BaseAtoms/Runtime/Events/Collider2DEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -11,3 +12,4 @@ namespace UnityAtoms.BaseAtoms
     {
     }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Events/Collider2DPairEvent.cs
+++ b/Packages/BaseAtoms/Runtime/Events/Collider2DPairEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -11,3 +12,4 @@ namespace UnityAtoms.BaseAtoms
     {
     }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Events/ColliderEvent.cs
+++ b/Packages/BaseAtoms/Runtime/Events/ColliderEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -11,3 +12,4 @@ namespace UnityAtoms.BaseAtoms
     {
     }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Events/ColliderPairEvent.cs
+++ b/Packages/BaseAtoms/Runtime/Events/ColliderPairEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -11,3 +12,4 @@ namespace UnityAtoms.BaseAtoms
     {
     }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Events/Collision2DEvent.cs
+++ b/Packages/BaseAtoms/Runtime/Events/Collision2DEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -11,3 +12,4 @@ namespace UnityAtoms.BaseAtoms
     {
     }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Events/Collision2DPairEvent.cs
+++ b/Packages/BaseAtoms/Runtime/Events/Collision2DPairEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -11,3 +12,4 @@ namespace UnityAtoms.BaseAtoms
     {
     }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Events/CollisionEvent.cs
+++ b/Packages/BaseAtoms/Runtime/Events/CollisionEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -11,3 +12,4 @@ namespace UnityAtoms.BaseAtoms
     {
     }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Events/CollisionPairEvent.cs
+++ b/Packages/BaseAtoms/Runtime/Events/CollisionPairEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -11,3 +12,4 @@ namespace UnityAtoms.BaseAtoms
     {
     }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Functions/Collider2DCollider2DFunction.cs
+++ b/Packages/BaseAtoms/Runtime/Functions/Collider2DCollider2DFunction.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 namespace UnityAtoms.BaseAtoms
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.BaseAtoms
     [EditorIcon("atom-icon-sand")]
     public abstract class Collider2DCollider2DFunction : AtomFunction<Collider2D, Collider2D> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Functions/ColliderColliderFunction.cs
+++ b/Packages/BaseAtoms/Runtime/Functions/ColliderColliderFunction.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 namespace UnityAtoms.BaseAtoms
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.BaseAtoms
     [EditorIcon("atom-icon-sand")]
     public abstract class ColliderColliderFunction : AtomFunction<Collider, Collider> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Functions/Collision2DCollision2DFunction.cs
+++ b/Packages/BaseAtoms/Runtime/Functions/Collision2DCollision2DFunction.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 namespace UnityAtoms.BaseAtoms
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.BaseAtoms
     [EditorIcon("atom-icon-sand")]
     public abstract class Collision2DCollision2DFunction : AtomFunction<Collision2D, Collision2D> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Functions/CollisionCollisionFunction.cs
+++ b/Packages/BaseAtoms/Runtime/Functions/CollisionCollisionFunction.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 namespace UnityAtoms.BaseAtoms
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.BaseAtoms
     [EditorIcon("atom-icon-sand")]
     public abstract class CollisionCollisionFunction : AtomFunction<Collision, Collision> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Pairs/Collider2DPair.cs
+++ b/Packages/BaseAtoms/Runtime/Pairs/Collider2DPair.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using System;
 using UnityEngine;
 namespace UnityAtoms.BaseAtoms
@@ -19,3 +20,4 @@ namespace UnityAtoms.BaseAtoms
         public void Deconstruct(out Collider2D item1, out Collider2D item2) { item1 = Item1; item2 = Item2; }
     }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Pairs/ColliderPair.cs
+++ b/Packages/BaseAtoms/Runtime/Pairs/ColliderPair.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using System;
 using UnityEngine;
 namespace UnityAtoms.BaseAtoms
@@ -19,3 +20,4 @@ namespace UnityAtoms.BaseAtoms
         public void Deconstruct(out Collider item1, out Collider item2) { item1 = Item1; item2 = Item2; }
     }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Pairs/Collision2DPair.cs
+++ b/Packages/BaseAtoms/Runtime/Pairs/Collision2DPair.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using System;
 using UnityEngine;
 namespace UnityAtoms.BaseAtoms
@@ -19,3 +20,4 @@ namespace UnityAtoms.BaseAtoms
         public void Deconstruct(out Collision2D item1, out Collision2D item2) { item1 = Item1; item2 = Item2; }
     }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Pairs/CollisionPair.cs
+++ b/Packages/BaseAtoms/Runtime/Pairs/CollisionPair.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using System;
 using UnityEngine;
 namespace UnityAtoms.BaseAtoms
@@ -19,3 +20,4 @@ namespace UnityAtoms.BaseAtoms
         public void Deconstruct(out Collision item1, out Collision item2) { item1 = Item1; item2 = Item2; }
     }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/References/Collider2DReference.cs
+++ b/Packages/BaseAtoms/Runtime/References/Collider2DReference.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using System;
 using UnityAtoms.BaseAtoms;
 using UnityEngine;
@@ -27,3 +28,4 @@ namespace UnityAtoms.BaseAtoms
         }
     }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/References/ColliderReference.cs
+++ b/Packages/BaseAtoms/Runtime/References/ColliderReference.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using System;
 using UnityAtoms.BaseAtoms;
 using UnityEngine;
@@ -27,3 +28,4 @@ namespace UnityAtoms.BaseAtoms
         }
     }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/References/Collision2DReference.cs
+++ b/Packages/BaseAtoms/Runtime/References/Collision2DReference.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using System;
 using UnityAtoms.BaseAtoms;
 using UnityEngine;
@@ -27,3 +28,4 @@ namespace UnityAtoms.BaseAtoms
         }
     }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/References/CollisionReference.cs
+++ b/Packages/BaseAtoms/Runtime/References/CollisionReference.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using System;
 using UnityAtoms.BaseAtoms;
 using UnityEngine;
@@ -27,3 +28,4 @@ namespace UnityAtoms.BaseAtoms
         }
     }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/SyncVariableInstancerToCollection/SyncCollider2DVariableInstancerToCollection.cs
+++ b/Packages/BaseAtoms/Runtime/SyncVariableInstancerToCollection/SyncCollider2DVariableInstancerToCollection.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityAtoms.BaseAtoms;
 using UnityEngine;
 
@@ -10,3 +11,4 @@ namespace UnityAtoms.BaseAtoms
     [EditorIcon("atom-icon-delicate")]
     public class SyncCollider2DVariableInstancerToCollection : SyncVariableInstancerToCollection<Collider2D, Collider2DVariable, Collider2DVariableInstancer> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/SyncVariableInstancerToCollection/SyncColliderVariableInstancerToCollection.cs
+++ b/Packages/BaseAtoms/Runtime/SyncVariableInstancerToCollection/SyncColliderVariableInstancerToCollection.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityAtoms.BaseAtoms;
 using UnityEngine;
 
@@ -10,3 +11,4 @@ namespace UnityAtoms.BaseAtoms
     [EditorIcon("atom-icon-delicate")]
     public class SyncColliderVariableInstancerToCollection : SyncVariableInstancerToCollection<Collider, ColliderVariable, ColliderVariableInstancer> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/SyncVariableInstancerToCollection/SyncCollision2DVariableInstancerToCollection.cs
+++ b/Packages/BaseAtoms/Runtime/SyncVariableInstancerToCollection/SyncCollision2DVariableInstancerToCollection.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityAtoms.BaseAtoms;
 using UnityEngine;
 
@@ -10,3 +11,4 @@ namespace UnityAtoms.BaseAtoms
     [EditorIcon("atom-icon-delicate")]
     public class SyncCollision2DVariableInstancerToCollection : SyncVariableInstancerToCollection<Collision2D, Collision2DVariable, Collision2DVariableInstancer> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/SyncVariableInstancerToCollection/SyncCollisionVariableInstancerToCollection.cs
+++ b/Packages/BaseAtoms/Runtime/SyncVariableInstancerToCollection/SyncCollisionVariableInstancerToCollection.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityAtoms.BaseAtoms;
 using UnityEngine;
 
@@ -10,3 +11,4 @@ namespace UnityAtoms.BaseAtoms
     [EditorIcon("atom-icon-delicate")]
     public class SyncCollisionVariableInstancerToCollection : SyncVariableInstancerToCollection<Collision, CollisionVariable, CollisionVariableInstancer> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/UnityAtoms.UnityAtomsBaseAtoms.Runtime.asmdef
+++ b/Packages/BaseAtoms/Runtime/UnityAtoms.UnityAtomsBaseAtoms.Runtime.asmdef
@@ -17,6 +17,11 @@
             "name": "com.unity.modules.physics",
             "expression": "0.0.0",
             "define": "PACKAGE_UNITY_PHYSICS"
+        },
+        {
+            "name": "com.unity.modules.physics2d",
+            "expression": "0.0.0",
+            "define": "PACKAGE_UNITY_PHYSICS2D"
         }
     ],
     "noEngineReferences": false

--- a/Packages/BaseAtoms/Runtime/UnityAtoms.UnityAtomsBaseAtoms.Runtime.asmdef
+++ b/Packages/BaseAtoms/Runtime/UnityAtoms.UnityAtomsBaseAtoms.Runtime.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "UnityAtoms.UnityAtomsBaseAtoms.Runtime",
+    "rootNamespace": "",
     "references": [
         "UnityAtoms.UnityAtomsCore.Editor",
         "UnityAtoms.UnityAtomsCore.Runtime"
@@ -11,6 +12,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.modules.physics",
+            "expression": "0.0.0",
+            "define": "PACKAGE_UNITY_PHYSICS"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Packages/BaseAtoms/Runtime/UnityEvents/Collider2DPairUnityEvent.cs
+++ b/Packages/BaseAtoms/Runtime/UnityEvents/Collider2DPairUnityEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using System;
 using UnityEngine.Events;
 using UnityEngine;
@@ -10,3 +11,4 @@ namespace UnityAtoms.BaseAtoms
     [Serializable]
     public sealed class Collider2DPairUnityEvent : UnityEvent<Collider2DPair> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/UnityEvents/Collider2DUnityEvent.cs
+++ b/Packages/BaseAtoms/Runtime/UnityEvents/Collider2DUnityEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using System;
 using UnityEngine.Events;
 using UnityEngine;
@@ -10,3 +11,4 @@ namespace UnityAtoms.BaseAtoms
     [Serializable]
     public sealed class Collider2DUnityEvent : UnityEvent<Collider2D> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/UnityEvents/ColliderPairUnityEvent.cs
+++ b/Packages/BaseAtoms/Runtime/UnityEvents/ColliderPairUnityEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using System;
 using UnityEngine.Events;
 using UnityEngine;
@@ -10,3 +11,4 @@ namespace UnityAtoms.BaseAtoms
     [Serializable]
     public sealed class ColliderPairUnityEvent : UnityEvent<ColliderPair> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/UnityEvents/ColliderUnityEvent.cs
+++ b/Packages/BaseAtoms/Runtime/UnityEvents/ColliderUnityEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using System;
 using UnityEngine.Events;
 using UnityEngine;
@@ -10,3 +11,4 @@ namespace UnityAtoms.BaseAtoms
     [Serializable]
     public sealed class ColliderUnityEvent : UnityEvent<Collider> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/UnityEvents/Collision2DPairUnityEvent.cs
+++ b/Packages/BaseAtoms/Runtime/UnityEvents/Collision2DPairUnityEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using System;
 using UnityEngine.Events;
 using UnityEngine;
@@ -10,3 +11,4 @@ namespace UnityAtoms.BaseAtoms
     [Serializable]
     public sealed class Collision2DPairUnityEvent : UnityEvent<Collision2DPair> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/UnityEvents/Collision2DUnityEvent.cs
+++ b/Packages/BaseAtoms/Runtime/UnityEvents/Collision2DUnityEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using System;
 using UnityEngine.Events;
 using UnityEngine;
@@ -10,3 +11,4 @@ namespace UnityAtoms.BaseAtoms
     [Serializable]
     public sealed class Collision2DUnityEvent : UnityEvent<Collision2D> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/UnityEvents/CollisionPairUnityEvent.cs
+++ b/Packages/BaseAtoms/Runtime/UnityEvents/CollisionPairUnityEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using System;
 using UnityEngine.Events;
 using UnityEngine;
@@ -10,3 +11,4 @@ namespace UnityAtoms.BaseAtoms
     [Serializable]
     public sealed class CollisionPairUnityEvent : UnityEvent<CollisionPair> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/UnityEvents/CollisionUnityEvent.cs
+++ b/Packages/BaseAtoms/Runtime/UnityEvents/CollisionUnityEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using System;
 using UnityEngine.Events;
 using UnityEngine;
@@ -10,3 +11,4 @@ namespace UnityAtoms.BaseAtoms
     [Serializable]
     public sealed class CollisionUnityEvent : UnityEvent<Collision> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/ValueLists/Collider2DValueList.cs
+++ b/Packages/BaseAtoms/Runtime/ValueLists/Collider2DValueList.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -9,3 +10,4 @@ namespace UnityAtoms.BaseAtoms
     [CreateAssetMenu(menuName = "Unity Atoms/Value Lists/Collider2D", fileName = "Collider2DValueList")]
     public sealed class Collider2DValueList : AtomValueList<Collider2D, Collider2DEvent> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/ValueLists/ColliderValueList.cs
+++ b/Packages/BaseAtoms/Runtime/ValueLists/ColliderValueList.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -9,3 +10,4 @@ namespace UnityAtoms.BaseAtoms
     [CreateAssetMenu(menuName = "Unity Atoms/Value Lists/Collider", fileName = "ColliderValueList")]
     public sealed class ColliderValueList : AtomValueList<Collider, ColliderEvent> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/ValueLists/Collision2DValueList.cs
+++ b/Packages/BaseAtoms/Runtime/ValueLists/Collision2DValueList.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -9,3 +10,4 @@ namespace UnityAtoms.BaseAtoms
     [CreateAssetMenu(menuName = "Unity Atoms/Value Lists/Collision2D", fileName = "Collision2DValueList")]
     public sealed class Collision2DValueList : AtomValueList<Collision2D, Collision2DEvent> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/ValueLists/CollisionValueList.cs
+++ b/Packages/BaseAtoms/Runtime/ValueLists/CollisionValueList.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 
 namespace UnityAtoms.BaseAtoms
@@ -9,3 +10,4 @@ namespace UnityAtoms.BaseAtoms
     [CreateAssetMenu(menuName = "Unity Atoms/Value Lists/Collision", fileName = "CollisionValueList")]
     public sealed class CollisionValueList : AtomValueList<Collision, CollisionEvent> { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/VariableInstancers/Collider2DVariableInstancer.cs
+++ b/Packages/BaseAtoms/Runtime/VariableInstancers/Collider2DVariableInstancer.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityAtoms.BaseAtoms;
 using UnityEngine;
 
@@ -17,3 +18,4 @@ namespace UnityAtoms.BaseAtoms
         Collider2DCollider2DFunction>
     { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/VariableInstancers/ColliderVariableInstancer.cs
+++ b/Packages/BaseAtoms/Runtime/VariableInstancers/ColliderVariableInstancer.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityAtoms.BaseAtoms;
 using UnityEngine;
 
@@ -17,3 +18,4 @@ namespace UnityAtoms.BaseAtoms
         ColliderColliderFunction>
     { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/VariableInstancers/Collision2DVariableInstancer.cs
+++ b/Packages/BaseAtoms/Runtime/VariableInstancers/Collision2DVariableInstancer.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityAtoms.BaseAtoms;
 using UnityEngine;
 
@@ -17,3 +18,4 @@ namespace UnityAtoms.BaseAtoms
         Collision2DCollision2DFunction>
     { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/VariableInstancers/CollisionVariableInstancer.cs
+++ b/Packages/BaseAtoms/Runtime/VariableInstancers/CollisionVariableInstancer.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityAtoms.BaseAtoms;
 using UnityEngine;
 
@@ -17,3 +18,4 @@ namespace UnityAtoms.BaseAtoms
         CollisionCollisionFunction>
     { }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Variables/Collider2DVariable.cs
+++ b/Packages/BaseAtoms/Runtime/Variables/Collider2DVariable.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using System;
 using UnityEngine;
 
@@ -16,3 +17,4 @@ namespace UnityAtoms.BaseAtoms
         }
     }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Variables/ColliderVariable.cs
+++ b/Packages/BaseAtoms/Runtime/Variables/ColliderVariable.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using System;
 using UnityEngine;
 
@@ -16,3 +17,4 @@ namespace UnityAtoms.BaseAtoms
         }
     }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Variables/Collision2DVariable.cs
+++ b/Packages/BaseAtoms/Runtime/Variables/Collision2DVariable.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using System;
 using UnityEngine;
 
@@ -16,3 +17,4 @@ namespace UnityAtoms.BaseAtoms
         }
     }
 }
+#endif

--- a/Packages/BaseAtoms/Runtime/Variables/CollisionVariable.cs
+++ b/Packages/BaseAtoms/Runtime/Variables/CollisionVariable.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using System;
 using UnityEngine;
 
@@ -16,3 +17,4 @@ namespace UnityAtoms.BaseAtoms
         }
     }
 }
+#endif

--- a/Packages/MonoHooks/Editor/Drawers/Constants/Collider2DGameObjectConstantDrawer.cs
+++ b/Packages/MonoHooks/Editor/Drawers/Constants/Collider2DGameObjectConstantDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/MonoHooks/Editor/Drawers/Constants/ColliderGameObjectConstantDrawer.cs
+++ b/Packages/MonoHooks/Editor/Drawers/Constants/ColliderGameObjectConstantDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/MonoHooks/Editor/Drawers/Constants/Collision2DGameObjectConstantDrawer.cs
+++ b/Packages/MonoHooks/Editor/Drawers/Constants/Collision2DGameObjectConstantDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/MonoHooks/Editor/Drawers/Constants/CollisionGameObjectConstantDrawer.cs
+++ b/Packages/MonoHooks/Editor/Drawers/Constants/CollisionGameObjectConstantDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/MonoHooks/Editor/Drawers/Events/Collider2DGameObjectEventDrawer.cs
+++ b/Packages/MonoHooks/Editor/Drawers/Events/Collider2DGameObjectEventDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/MonoHooks/Editor/Drawers/Events/Collider2DGameObjectPairEventDrawer.cs
+++ b/Packages/MonoHooks/Editor/Drawers/Events/Collider2DGameObjectPairEventDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/MonoHooks/Editor/Drawers/Events/ColliderGameObjectEventDrawer.cs
+++ b/Packages/MonoHooks/Editor/Drawers/Events/ColliderGameObjectEventDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/MonoHooks/Editor/Drawers/Events/ColliderGameObjectPairEventDrawer.cs
+++ b/Packages/MonoHooks/Editor/Drawers/Events/ColliderGameObjectPairEventDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/MonoHooks/Editor/Drawers/Events/Collision2DGameObjectEventDrawer.cs
+++ b/Packages/MonoHooks/Editor/Drawers/Events/Collision2DGameObjectEventDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/MonoHooks/Editor/Drawers/Events/Collision2DGameObjectPairEventDrawer.cs
+++ b/Packages/MonoHooks/Editor/Drawers/Events/Collision2DGameObjectPairEventDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/MonoHooks/Editor/Drawers/Events/CollisionGameObjectEventDrawer.cs
+++ b/Packages/MonoHooks/Editor/Drawers/Events/CollisionGameObjectEventDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/MonoHooks/Editor/Drawers/Events/CollisionGameObjectPairEventDrawer.cs
+++ b/Packages/MonoHooks/Editor/Drawers/Events/CollisionGameObjectPairEventDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/MonoHooks/Editor/Drawers/ValueLists/Collider2DGameObjectValueListDrawer.cs
+++ b/Packages/MonoHooks/Editor/Drawers/ValueLists/Collider2DGameObjectValueListDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/MonoHooks/Editor/Drawers/ValueLists/ColliderGameObjectValueListDrawer.cs
+++ b/Packages/MonoHooks/Editor/Drawers/ValueLists/ColliderGameObjectValueListDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/MonoHooks/Editor/Drawers/ValueLists/Collision2DGameObjectValueListDrawer.cs
+++ b/Packages/MonoHooks/Editor/Drawers/ValueLists/Collision2DGameObjectValueListDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/MonoHooks/Editor/Drawers/ValueLists/CollisionGameObjectValueListDrawer.cs
+++ b/Packages/MonoHooks/Editor/Drawers/ValueLists/CollisionGameObjectValueListDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/MonoHooks/Editor/Drawers/Variables/Collider2DGameObjectVariableDrawer.cs
+++ b/Packages/MonoHooks/Editor/Drawers/Variables/Collider2DGameObjectVariableDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/MonoHooks/Editor/Drawers/Variables/ColliderGameObjectVariableDrawer.cs
+++ b/Packages/MonoHooks/Editor/Drawers/Variables/ColliderGameObjectVariableDrawer.cs
@@ -1,6 +1,6 @@
-#if UNITY_2019_1_OR_NEWER
-using UnityEditor;
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS
 using UnityAtoms.Editor;
+using UnityEditor;
 
 namespace UnityAtoms.MonoHooks.Editor
 {

--- a/Packages/MonoHooks/Editor/Drawers/Variables/Collision2DGameObjectVariableDrawer.cs
+++ b/Packages/MonoHooks/Editor/Drawers/Variables/Collision2DGameObjectVariableDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/MonoHooks/Editor/Drawers/Variables/CollisionGameObjectVariableDrawer.cs
+++ b/Packages/MonoHooks/Editor/Drawers/Variables/CollisionGameObjectVariableDrawer.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityAtoms.Editor;
 

--- a/Packages/MonoHooks/Editor/Editors/Events/Collider2DGameObjectEventEditor.cs
+++ b/Packages/MonoHooks/Editor/Editors/Events/Collider2DGameObjectEventEditor.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityEngine.UIElements;
 using UnityAtoms.Editor;

--- a/Packages/MonoHooks/Editor/Editors/Events/Collider2DGameObjectPairEventEditor.cs
+++ b/Packages/MonoHooks/Editor/Editors/Events/Collider2DGameObjectPairEventEditor.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityEngine.UIElements;
 using UnityAtoms.Editor;

--- a/Packages/MonoHooks/Editor/Editors/Events/ColliderGameObjectEventEditor.cs
+++ b/Packages/MonoHooks/Editor/Editors/Events/ColliderGameObjectEventEditor.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityEngine.UIElements;
 using UnityAtoms.Editor;

--- a/Packages/MonoHooks/Editor/Editors/Events/ColliderGameObjectPairEventEditor.cs
+++ b/Packages/MonoHooks/Editor/Editors/Events/ColliderGameObjectPairEventEditor.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityEngine.UIElements;
 using UnityAtoms.Editor;

--- a/Packages/MonoHooks/Editor/Editors/Events/Collision2DGameObjectEventEditor.cs
+++ b/Packages/MonoHooks/Editor/Editors/Events/Collision2DGameObjectEventEditor.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityEngine.UIElements;
 using UnityAtoms.Editor;

--- a/Packages/MonoHooks/Editor/Editors/Events/Collision2DGameObjectPairEventEditor.cs
+++ b/Packages/MonoHooks/Editor/Editors/Events/Collision2DGameObjectPairEventEditor.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityEngine.UIElements;
 using UnityAtoms.Editor;

--- a/Packages/MonoHooks/Editor/Editors/Events/CollisionGameObjectEventEditor.cs
+++ b/Packages/MonoHooks/Editor/Editors/Events/CollisionGameObjectEventEditor.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityEngine.UIElements;
 using UnityAtoms.Editor;

--- a/Packages/MonoHooks/Editor/Editors/Events/CollisionGameObjectPairEventEditor.cs
+++ b/Packages/MonoHooks/Editor/Editors/Events/CollisionGameObjectPairEventEditor.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_1_OR_NEWER && PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityEngine.UIElements;
 using UnityAtoms.Editor;
@@ -12,4 +12,5 @@ namespace UnityAtoms.MonoHooks.Editor
     [CustomEditor(typeof(CollisionGameObjectPairEvent))]
     public sealed class CollisionGameObjectPairEventEditor : AtomEventEditor<CollisionGameObjectPair, CollisionGameObjectPairEvent> { }
 }
+
 #endif

--- a/Packages/MonoHooks/Editor/Editors/Variables/Collider2DGameObjectVariableEditor.cs
+++ b/Packages/MonoHooks/Editor/Editors/Variables/Collider2DGameObjectVariableEditor.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityAtoms.Editor;
 using UnityAtoms.MonoHooks;
@@ -10,3 +11,4 @@ namespace UnityAtoms.MonoHooks.Editor
     [CustomEditor(typeof(Collider2DGameObjectVariable))]
     public sealed class Collider2DGameObjectVariableEditor : AtomVariableEditor<Collider2DGameObject, Collider2DGameObjectPair> { }
 }
+#endif

--- a/Packages/MonoHooks/Editor/Editors/Variables/ColliderGameObjectVariableEditor.cs
+++ b/Packages/MonoHooks/Editor/Editors/Variables/ColliderGameObjectVariableEditor.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityAtoms.Editor;
 using UnityAtoms.MonoHooks;
@@ -10,3 +11,4 @@ namespace UnityAtoms.MonoHooks.Editor
     [CustomEditor(typeof(ColliderGameObjectVariable))]
     public sealed class ColliderGameObjectVariableEditor : AtomVariableEditor<ColliderGameObject, ColliderGameObjectPair> { }
 }
+#endif

--- a/Packages/MonoHooks/Editor/Editors/Variables/Collision2DGameObjectVariableEditor.cs
+++ b/Packages/MonoHooks/Editor/Editors/Variables/Collision2DGameObjectVariableEditor.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEditor;
 using UnityAtoms.Editor;
 using UnityAtoms.MonoHooks;
@@ -10,3 +11,4 @@ namespace UnityAtoms.MonoHooks.Editor
     [CustomEditor(typeof(Collision2DGameObjectVariable))]
     public sealed class Collision2DGameObjectVariableEditor : AtomVariableEditor<Collision2DGameObject, Collision2DGameObjectPair> { }
 }
+#endif

--- a/Packages/MonoHooks/Editor/Editors/Variables/CollisionGameObjectVariableEditor.cs
+++ b/Packages/MonoHooks/Editor/Editors/Variables/CollisionGameObjectVariableEditor.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEditor;
 using UnityAtoms.Editor;
 using UnityAtoms.MonoHooks;
@@ -10,3 +11,4 @@ namespace UnityAtoms.MonoHooks.Editor
     [CustomEditor(typeof(CollisionGameObjectVariable))]
     public sealed class CollisionGameObjectVariableEditor : AtomVariableEditor<CollisionGameObject, CollisionGameObjectPair> { }
 }
+#endif

--- a/Packages/MonoHooks/Editor/UnityAtoms.UnityAtomsMonoHooks.Editor.asmdef
+++ b/Packages/MonoHooks/Editor/UnityAtoms.UnityAtomsMonoHooks.Editor.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "UnityAtoms.UnityAtomsMonoHooks.Editor",
+    "rootNamespace": "",
     "references": [
         "UnityAtoms.UnityAtomsCore.Runtime",
         "UnityAtoms.UnityAtomsCore.Editor",
@@ -16,6 +17,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.modules.physics",
+            "expression": "0.0.0",
+            "define": "PACKAGE_UNITY_PHYSICS"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Packages/MonoHooks/Editor/UnityAtoms.UnityAtomsMonoHooks.Editor.asmdef
+++ b/Packages/MonoHooks/Editor/UnityAtoms.UnityAtomsMonoHooks.Editor.asmdef
@@ -22,6 +22,11 @@
             "name": "com.unity.modules.physics",
             "expression": "0.0.0",
             "define": "PACKAGE_UNITY_PHYSICS"
+        },
+        {
+            "name": "com.unity.modules.physics2d",
+            "expression": "0.0.0",
+            "define": "PACKAGE_UNITY_PHYSICS2D"
         }
     ],
     "noEngineReferences": false

--- a/Packages/MonoHooks/Runtime/Actions/Collider2DGameObjectAction.cs
+++ b/Packages/MonoHooks/Runtime/Actions/Collider2DGameObjectAction.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityAtoms.MonoHooks;
 namespace UnityAtoms.MonoHooks
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.MonoHooks
     [EditorIcon("atom-icon-purple")]
     public abstract class Collider2DGameObjectAction : AtomAction<Collider2DGameObject> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Actions/Collider2DGameObjectPairAction.cs
+++ b/Packages/MonoHooks/Runtime/Actions/Collider2DGameObjectPairAction.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityAtoms.MonoHooks;
 namespace UnityAtoms.MonoHooks
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.MonoHooks
     [EditorIcon("atom-icon-purple")]
     public abstract class Collider2DGameObjectPairAction : AtomAction<Collider2DGameObjectPair> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Actions/ColliderGameObjectAction.cs
+++ b/Packages/MonoHooks/Runtime/Actions/ColliderGameObjectAction.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityAtoms.MonoHooks;
 namespace UnityAtoms.MonoHooks
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.MonoHooks
     [EditorIcon("atom-icon-purple")]
     public abstract class ColliderGameObjectAction : AtomAction<ColliderGameObject> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Actions/ColliderGameObjectPairAction.cs
+++ b/Packages/MonoHooks/Runtime/Actions/ColliderGameObjectPairAction.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityAtoms.MonoHooks;
 namespace UnityAtoms.MonoHooks
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.MonoHooks
     [EditorIcon("atom-icon-purple")]
     public abstract class ColliderGameObjectPairAction : AtomAction<ColliderGameObjectPair> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Actions/Collision2DGameObjectAction.cs
+++ b/Packages/MonoHooks/Runtime/Actions/Collision2DGameObjectAction.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityAtoms.MonoHooks;
 namespace UnityAtoms.MonoHooks
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.MonoHooks
     [EditorIcon("atom-icon-purple")]
     public abstract class Collision2DGameObjectAction : AtomAction<Collision2DGameObject> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Actions/Collision2DGameObjectPairAction.cs
+++ b/Packages/MonoHooks/Runtime/Actions/Collision2DGameObjectPairAction.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityAtoms.MonoHooks;
 namespace UnityAtoms.MonoHooks
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.MonoHooks
     [EditorIcon("atom-icon-purple")]
     public abstract class Collision2DGameObjectPairAction : AtomAction<Collision2DGameObjectPair> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Actions/CollisionGameObjectAction.cs
+++ b/Packages/MonoHooks/Runtime/Actions/CollisionGameObjectAction.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityAtoms.MonoHooks;
 namespace UnityAtoms.MonoHooks
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.MonoHooks
     [EditorIcon("atom-icon-purple")]
     public abstract class CollisionGameObjectAction : AtomAction<CollisionGameObject> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Actions/CollisionGameObjectPairAction.cs
+++ b/Packages/MonoHooks/Runtime/Actions/CollisionGameObjectPairAction.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityAtoms.MonoHooks;
 namespace UnityAtoms.MonoHooks
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.MonoHooks
     [EditorIcon("atom-icon-purple")]
     public abstract class CollisionGameObjectPairAction : AtomAction<CollisionGameObjectPair> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Actions/SetVariableValue/SetCollider2DGameObjectVariableValue.cs
+++ b/Packages/MonoHooks/Runtime/Actions/SetVariableValue/SetCollider2DGameObjectVariableValue.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 using UnityAtoms.BaseAtoms;
 using UnityAtoms.MonoHooks;
@@ -21,3 +22,4 @@ namespace UnityAtoms.MonoHooks
         Collider2DGameObjectVariableInstancer>
     { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Actions/SetVariableValue/SetColliderGameObjectVariableValue.cs
+++ b/Packages/MonoHooks/Runtime/Actions/SetVariableValue/SetColliderGameObjectVariableValue.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 using UnityAtoms.BaseAtoms;
 using UnityAtoms.MonoHooks;
@@ -21,3 +22,4 @@ namespace UnityAtoms.MonoHooks
         ColliderGameObjectVariableInstancer>
     { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Actions/SetVariableValue/SetCollision2DGameObjectVariableValue.cs
+++ b/Packages/MonoHooks/Runtime/Actions/SetVariableValue/SetCollision2DGameObjectVariableValue.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 using UnityAtoms.BaseAtoms;
 using UnityAtoms.MonoHooks;
@@ -21,3 +22,4 @@ namespace UnityAtoms.MonoHooks
         Collision2DGameObjectVariableInstancer>
     { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Actions/SetVariableValue/SetCollisionGameObjectVariableValue.cs
+++ b/Packages/MonoHooks/Runtime/Actions/SetVariableValue/SetCollisionGameObjectVariableValue.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 using UnityAtoms.BaseAtoms;
 using UnityAtoms.MonoHooks;
@@ -21,3 +22,4 @@ namespace UnityAtoms.MonoHooks
         CollisionGameObjectVariableInstancer>
     { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Conditions/Collider2DGameObjectCondition.cs
+++ b/Packages/MonoHooks/Runtime/Conditions/Collider2DGameObjectCondition.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityAtoms.MonoHooks;
 namespace UnityAtoms.MonoHooks
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.MonoHooks
     [EditorIcon("atom-icon-teal")]
     public abstract class Collider2DGameObjectCondition : AtomCondition<Collider2DGameObject> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Conditions/ColliderGameObjectCondition.cs
+++ b/Packages/MonoHooks/Runtime/Conditions/ColliderGameObjectCondition.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityAtoms.MonoHooks;
 namespace UnityAtoms.MonoHooks
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.MonoHooks
     [EditorIcon("atom-icon-teal")]
     public abstract class ColliderGameObjectCondition : AtomCondition<ColliderGameObject> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Conditions/Collision2DGameObjectCondition.cs
+++ b/Packages/MonoHooks/Runtime/Conditions/Collision2DGameObjectCondition.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityAtoms.MonoHooks;
 namespace UnityAtoms.MonoHooks
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.MonoHooks
     [EditorIcon("atom-icon-teal")]
     public abstract class Collision2DGameObjectCondition : AtomCondition<Collision2DGameObject> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Conditions/CollisionGameObjectCondition.cs
+++ b/Packages/MonoHooks/Runtime/Conditions/CollisionGameObjectCondition.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityAtoms.MonoHooks;
 namespace UnityAtoms.MonoHooks
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.MonoHooks
     [EditorIcon("atom-icon-teal")]
     public abstract class CollisionGameObjectCondition : AtomCondition<CollisionGameObject> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Constants/Collider2DGameObjectConstant.cs
+++ b/Packages/MonoHooks/Runtime/Constants/Collider2DGameObjectConstant.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -10,3 +11,4 @@ namespace UnityAtoms.MonoHooks
     [CreateAssetMenu(menuName = "Unity Atoms/Constants/Collider2DGameObject", fileName = "Collider2DGameObjectConstant")]
     public sealed class Collider2DGameObjectConstant : AtomBaseVariable<Collider2DGameObject> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Constants/ColliderGameObjectConstant.cs
+++ b/Packages/MonoHooks/Runtime/Constants/ColliderGameObjectConstant.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -10,3 +11,4 @@ namespace UnityAtoms.MonoHooks
     [CreateAssetMenu(menuName = "Unity Atoms/Constants/ColliderGameObject", fileName = "ColliderGameObjectConstant")]
     public sealed class ColliderGameObjectConstant : AtomBaseVariable<ColliderGameObject> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Constants/Collision2DGameObjectConstant.cs
+++ b/Packages/MonoHooks/Runtime/Constants/Collision2DGameObjectConstant.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -10,3 +11,4 @@ namespace UnityAtoms.MonoHooks
     [CreateAssetMenu(menuName = "Unity Atoms/Constants/Collision2DGameObject", fileName = "Collision2DGameObjectConstant")]
     public sealed class Collision2DGameObjectConstant : AtomBaseVariable<Collision2DGameObject> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Constants/CollisionGameObjectConstant.cs
+++ b/Packages/MonoHooks/Runtime/Constants/CollisionGameObjectConstant.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -10,3 +11,4 @@ namespace UnityAtoms.MonoHooks
     [CreateAssetMenu(menuName = "Unity Atoms/Constants/CollisionGameObject", fileName = "CollisionGameObjectConstant")]
     public sealed class CollisionGameObjectConstant : AtomBaseVariable<CollisionGameObject> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/EventInstancers/Collider2DGameObjectEventInstancer.cs
+++ b/Packages/MonoHooks/Runtime/EventInstancers/Collider2DGameObjectEventInstancer.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -10,3 +11,4 @@ namespace UnityAtoms.MonoHooks
     [AddComponentMenu("Unity Atoms/Event Instancers/Collider2DGameObject Event Instancer")]
     public class Collider2DGameObjectEventInstancer : AtomEventInstancer<Collider2DGameObject, Collider2DGameObjectEvent> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/EventInstancers/Collider2DGameObjectPairEventInstancer.cs
+++ b/Packages/MonoHooks/Runtime/EventInstancers/Collider2DGameObjectPairEventInstancer.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -10,3 +11,4 @@ namespace UnityAtoms.MonoHooks
     [AddComponentMenu("Unity Atoms/Event Instancers/Collider2DGameObjectPair Event Instancer")]
     public class Collider2DGameObjectPairEventInstancer : AtomEventInstancer<Collider2DGameObjectPair, Collider2DGameObjectPairEvent> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/EventInstancers/ColliderGameObjectEventInstancer.cs
+++ b/Packages/MonoHooks/Runtime/EventInstancers/ColliderGameObjectEventInstancer.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -10,3 +11,4 @@ namespace UnityAtoms.MonoHooks
     [AddComponentMenu("Unity Atoms/Event Instancers/ColliderGameObject Event Instancer")]
     public class ColliderGameObjectEventInstancer : AtomEventInstancer<ColliderGameObject, ColliderGameObjectEvent> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/EventInstancers/ColliderGameObjectPairEventInstancer.cs
+++ b/Packages/MonoHooks/Runtime/EventInstancers/ColliderGameObjectPairEventInstancer.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -10,3 +11,4 @@ namespace UnityAtoms.MonoHooks
     [AddComponentMenu("Unity Atoms/Event Instancers/ColliderGameObjectPair Event Instancer")]
     public class ColliderGameObjectPairEventInstancer : AtomEventInstancer<ColliderGameObjectPair, ColliderGameObjectPairEvent> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/EventInstancers/Collision2DGameObjectEventInstancer.cs
+++ b/Packages/MonoHooks/Runtime/EventInstancers/Collision2DGameObjectEventInstancer.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -10,3 +11,4 @@ namespace UnityAtoms.MonoHooks
     [AddComponentMenu("Unity Atoms/Event Instancers/Collision2DGameObject Event Instancer")]
     public class Collision2DGameObjectEventInstancer : AtomEventInstancer<Collision2DGameObject, Collision2DGameObjectEvent> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/EventInstancers/Collision2DGameObjectPairEventInstancer.cs
+++ b/Packages/MonoHooks/Runtime/EventInstancers/Collision2DGameObjectPairEventInstancer.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -10,3 +11,4 @@ namespace UnityAtoms.MonoHooks
     [AddComponentMenu("Unity Atoms/Event Instancers/Collision2DGameObjectPair Event Instancer")]
     public class Collision2DGameObjectPairEventInstancer : AtomEventInstancer<Collision2DGameObjectPair, Collision2DGameObjectPairEvent> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/EventInstancers/CollisionGameObjectEventInstancer.cs
+++ b/Packages/MonoHooks/Runtime/EventInstancers/CollisionGameObjectEventInstancer.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -10,3 +11,4 @@ namespace UnityAtoms.MonoHooks
     [AddComponentMenu("Unity Atoms/Event Instancers/CollisionGameObject Event Instancer")]
     public class CollisionGameObjectEventInstancer : AtomEventInstancer<CollisionGameObject, CollisionGameObjectEvent> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/EventInstancers/CollisionGameObjectPairEventInstancer.cs
+++ b/Packages/MonoHooks/Runtime/EventInstancers/CollisionGameObjectPairEventInstancer.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -10,3 +11,4 @@ namespace UnityAtoms.MonoHooks
     [AddComponentMenu("Unity Atoms/Event Instancers/CollisionGameObjectPair Event Instancer")]
     public class CollisionGameObjectPairEventInstancer : AtomEventInstancer<CollisionGameObjectPair, CollisionGameObjectPairEvent> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/EventReferenceListeners/Collider2DGameObjectEventReferenceListener.cs
+++ b/Packages/MonoHooks/Runtime/EventReferenceListeners/Collider2DGameObjectEventReferenceListener.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -15,3 +16,4 @@ namespace UnityAtoms.MonoHooks
         Collider2DGameObjectUnityEvent>
     { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/EventReferenceListeners/Collider2DGameObjectPairEventReferenceListener.cs
+++ b/Packages/MonoHooks/Runtime/EventReferenceListeners/Collider2DGameObjectPairEventReferenceListener.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -15,3 +16,4 @@ namespace UnityAtoms.MonoHooks
         Collider2DGameObjectPairUnityEvent>
     { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/EventReferenceListeners/ColliderGameObjectEventReferenceListener.cs
+++ b/Packages/MonoHooks/Runtime/EventReferenceListeners/ColliderGameObjectEventReferenceListener.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -15,3 +16,4 @@ namespace UnityAtoms.MonoHooks
         ColliderGameObjectUnityEvent>
     { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/EventReferenceListeners/ColliderGameObjectPairEventReferenceListener.cs
+++ b/Packages/MonoHooks/Runtime/EventReferenceListeners/ColliderGameObjectPairEventReferenceListener.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -15,3 +16,4 @@ namespace UnityAtoms.MonoHooks
         ColliderGameObjectPairUnityEvent>
     { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/EventReferenceListeners/Collision2DGameObjectEventReferenceListener.cs
+++ b/Packages/MonoHooks/Runtime/EventReferenceListeners/Collision2DGameObjectEventReferenceListener.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -15,3 +16,4 @@ namespace UnityAtoms.MonoHooks
         Collision2DGameObjectUnityEvent>
     { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/EventReferenceListeners/Collision2DGameObjectPairEventReferenceListener.cs
+++ b/Packages/MonoHooks/Runtime/EventReferenceListeners/Collision2DGameObjectPairEventReferenceListener.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -15,3 +16,4 @@ namespace UnityAtoms.MonoHooks
         Collision2DGameObjectPairUnityEvent>
     { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/EventReferenceListeners/CollisionGameObjectEventReferenceListener.cs
+++ b/Packages/MonoHooks/Runtime/EventReferenceListeners/CollisionGameObjectEventReferenceListener.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -15,3 +16,4 @@ namespace UnityAtoms.MonoHooks
         CollisionGameObjectUnityEvent>
     { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/EventReferenceListeners/CollisionGameObjectPairEventReferenceListener.cs
+++ b/Packages/MonoHooks/Runtime/EventReferenceListeners/CollisionGameObjectPairEventReferenceListener.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -15,3 +16,4 @@ namespace UnityAtoms.MonoHooks
         CollisionGameObjectPairUnityEvent>
     { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/EventReferences/Collider2DGameObjectEventReference.cs
+++ b/Packages/MonoHooks/Runtime/EventReferences/Collider2DGameObjectEventReference.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using System;
 using UnityAtoms.MonoHooks;
 
@@ -15,3 +16,4 @@ namespace UnityAtoms.MonoHooks
         Collider2DGameObjectEventInstancer>, IGetEvent 
     { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/EventReferences/Collider2DGameObjectPairEventReference.cs
+++ b/Packages/MonoHooks/Runtime/EventReferences/Collider2DGameObjectPairEventReference.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using System;
 using UnityAtoms.MonoHooks;
 
@@ -15,3 +16,4 @@ namespace UnityAtoms.MonoHooks
         Collider2DGameObjectPairEventInstancer>, IGetEvent 
     { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/EventReferences/ColliderGameObjectEventReference.cs
+++ b/Packages/MonoHooks/Runtime/EventReferences/ColliderGameObjectEventReference.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using System;
 using UnityAtoms.MonoHooks;
 
@@ -15,3 +16,4 @@ namespace UnityAtoms.MonoHooks
         ColliderGameObjectEventInstancer>, IGetEvent 
     { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/EventReferences/ColliderGameObjectPairEventReference.cs
+++ b/Packages/MonoHooks/Runtime/EventReferences/ColliderGameObjectPairEventReference.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using System;
 using UnityAtoms.MonoHooks;
 
@@ -15,3 +16,4 @@ namespace UnityAtoms.MonoHooks
         ColliderGameObjectPairEventInstancer>, IGetEvent 
     { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/EventReferences/Collision2DGameObjectEventReference.cs
+++ b/Packages/MonoHooks/Runtime/EventReferences/Collision2DGameObjectEventReference.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using System;
 using UnityAtoms.MonoHooks;
 
@@ -15,3 +16,4 @@ namespace UnityAtoms.MonoHooks
         Collision2DGameObjectEventInstancer>, IGetEvent 
     { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/EventReferences/Collision2DGameObjectPairEventReference.cs
+++ b/Packages/MonoHooks/Runtime/EventReferences/Collision2DGameObjectPairEventReference.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using System;
 using UnityAtoms.MonoHooks;
 
@@ -15,3 +16,4 @@ namespace UnityAtoms.MonoHooks
         Collision2DGameObjectPairEventInstancer>, IGetEvent 
     { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/EventReferences/CollisionGameObjectEventReference.cs
+++ b/Packages/MonoHooks/Runtime/EventReferences/CollisionGameObjectEventReference.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using System;
 using UnityAtoms.MonoHooks;
 
@@ -15,3 +16,4 @@ namespace UnityAtoms.MonoHooks
         CollisionGameObjectEventInstancer>, IGetEvent 
     { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/EventReferences/CollisionGameObjectPairEventReference.cs
+++ b/Packages/MonoHooks/Runtime/EventReferences/CollisionGameObjectPairEventReference.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using System;
 using UnityAtoms.MonoHooks;
 
@@ -15,3 +16,4 @@ namespace UnityAtoms.MonoHooks
         CollisionGameObjectPairEventInstancer>, IGetEvent 
     { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Events/Collider2DGameObjectEvent.cs
+++ b/Packages/MonoHooks/Runtime/Events/Collider2DGameObjectEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -12,3 +13,4 @@ namespace UnityAtoms.MonoHooks
     {
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Events/Collider2DGameObjectPairEvent.cs
+++ b/Packages/MonoHooks/Runtime/Events/Collider2DGameObjectPairEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -12,3 +13,4 @@ namespace UnityAtoms.MonoHooks
     {
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Events/ColliderGameObjectEvent.cs
+++ b/Packages/MonoHooks/Runtime/Events/ColliderGameObjectEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -12,3 +13,4 @@ namespace UnityAtoms.MonoHooks
     {
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Events/ColliderGameObjectPairEvent.cs
+++ b/Packages/MonoHooks/Runtime/Events/ColliderGameObjectPairEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -12,3 +13,4 @@ namespace UnityAtoms.MonoHooks
     {
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Events/Collision2DGameObjectEvent.cs
+++ b/Packages/MonoHooks/Runtime/Events/Collision2DGameObjectEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -12,3 +13,4 @@ namespace UnityAtoms.MonoHooks
     {
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Events/Collision2DGameObjectPairEvent.cs
+++ b/Packages/MonoHooks/Runtime/Events/Collision2DGameObjectPairEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -12,3 +13,4 @@ namespace UnityAtoms.MonoHooks
     {
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Events/CollisionGameObjectEvent.cs
+++ b/Packages/MonoHooks/Runtime/Events/CollisionGameObjectEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -12,3 +13,4 @@ namespace UnityAtoms.MonoHooks
     {
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Events/CollisionGameObjectPairEvent.cs
+++ b/Packages/MonoHooks/Runtime/Events/CollisionGameObjectPairEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -12,3 +13,4 @@ namespace UnityAtoms.MonoHooks
     {
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Functions/Collider2DGameObjectCollider2DGameObjectFunction.cs
+++ b/Packages/MonoHooks/Runtime/Functions/Collider2DGameObjectCollider2DGameObjectFunction.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityAtoms.MonoHooks;
 namespace UnityAtoms.MonoHooks
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.MonoHooks
     [EditorIcon("atom-icon-sand")]
     public abstract class Collider2DGameObjectCollider2DGameObjectFunction : AtomFunction<Collider2DGameObject, Collider2DGameObject> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Functions/ColliderGameObjectColliderGameObjectFunction.cs
+++ b/Packages/MonoHooks/Runtime/Functions/ColliderGameObjectColliderGameObjectFunction.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityAtoms.MonoHooks;
 namespace UnityAtoms.MonoHooks
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.MonoHooks
     [EditorIcon("atom-icon-sand")]
     public abstract class ColliderGameObjectColliderGameObjectFunction : AtomFunction<ColliderGameObject, ColliderGameObject> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Functions/Collision2DGameObjectCollision2DGameObjectFunction.cs
+++ b/Packages/MonoHooks/Runtime/Functions/Collision2DGameObjectCollision2DGameObjectFunction.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityAtoms.MonoHooks;
 namespace UnityAtoms.MonoHooks
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.MonoHooks
     [EditorIcon("atom-icon-sand")]
     public abstract class Collision2DGameObjectCollision2DGameObjectFunction : AtomFunction<Collision2DGameObject, Collision2DGameObject> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Functions/CollisionGameObjectCollisionGameObjectFunction.cs
+++ b/Packages/MonoHooks/Runtime/Functions/CollisionGameObjectCollisionGameObjectFunction.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityAtoms.MonoHooks;
 namespace UnityAtoms.MonoHooks
 {
@@ -7,3 +8,4 @@ namespace UnityAtoms.MonoHooks
     [EditorIcon("atom-icon-sand")]
     public abstract class CollisionGameObjectCollisionGameObjectFunction : AtomFunction<CollisionGameObject, CollisionGameObject> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Hooks/Collider2DHook.cs
+++ b/Packages/MonoHooks/Runtime/Hooks/Collider2DHook.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 using UnityAtoms.BaseAtoms;
 
@@ -40,3 +41,4 @@ namespace UnityAtoms.MonoHooks
         }
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Hooks/ColliderHook.cs
+++ b/Packages/MonoHooks/Runtime/Hooks/ColliderHook.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 using UnityAtoms.BaseAtoms;
 
@@ -40,3 +41,4 @@ namespace UnityAtoms.MonoHooks
         }
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Hooks/Collision2DHook.cs
+++ b/Packages/MonoHooks/Runtime/Hooks/Collision2DHook.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 using UnityAtoms.BaseAtoms;
 
@@ -40,3 +41,4 @@ namespace UnityAtoms.MonoHooks
         }
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Hooks/CollisionHook.cs
+++ b/Packages/MonoHooks/Runtime/Hooks/CollisionHook.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 using UnityAtoms.BaseAtoms;
 
@@ -40,3 +41,4 @@ namespace UnityAtoms.MonoHooks
         }
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Hooks/OnCollision2DHook.cs
+++ b/Packages/MonoHooks/Runtime/Hooks/OnCollision2DHook.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 
 namespace UnityAtoms.MonoHooks
@@ -41,3 +42,4 @@ namespace UnityAtoms.MonoHooks
         }
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Hooks/OnCollisionHook.cs
+++ b/Packages/MonoHooks/Runtime/Hooks/OnCollisionHook.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 
 namespace UnityAtoms.MonoHooks
@@ -41,3 +42,4 @@ namespace UnityAtoms.MonoHooks
         }
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Hooks/OnTrigger2DHook.cs
+++ b/Packages/MonoHooks/Runtime/Hooks/OnTrigger2DHook.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+#if PACKAGE_UNITY_PHYSICS2D
+using UnityEngine;
 
 namespace UnityAtoms.MonoHooks
 {
@@ -41,3 +42,4 @@ namespace UnityAtoms.MonoHooks
         }
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Hooks/OnTriggerHook.cs
+++ b/Packages/MonoHooks/Runtime/Hooks/OnTriggerHook.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 
 namespace UnityAtoms.MonoHooks
@@ -41,3 +42,4 @@ namespace UnityAtoms.MonoHooks
         }
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Pairs/Collider2DGameObjectPair.cs
+++ b/Packages/MonoHooks/Runtime/Pairs/Collider2DGameObjectPair.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using System;
 using UnityEngine;
 using UnityAtoms.MonoHooks;
@@ -20,3 +21,4 @@ namespace UnityAtoms.MonoHooks
         public void Deconstruct(out Collider2DGameObject item1, out Collider2DGameObject item2) { item1 = Item1; item2 = Item2; }
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Pairs/ColliderGameObjectPair.cs
+++ b/Packages/MonoHooks/Runtime/Pairs/ColliderGameObjectPair.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using System;
 using UnityEngine;
 using UnityAtoms.MonoHooks;
@@ -20,3 +21,4 @@ namespace UnityAtoms.MonoHooks
         public void Deconstruct(out ColliderGameObject item1, out ColliderGameObject item2) { item1 = Item1; item2 = Item2; }
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Pairs/Collision2DGameObjectPair.cs
+++ b/Packages/MonoHooks/Runtime/Pairs/Collision2DGameObjectPair.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using System;
 using UnityEngine;
 using UnityAtoms.MonoHooks;
@@ -20,3 +21,4 @@ namespace UnityAtoms.MonoHooks
         public void Deconstruct(out Collision2DGameObject item1, out Collision2DGameObject item2) { item1 = Item1; item2 = Item2; }
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Pairs/CollisionGameObjectPair.cs
+++ b/Packages/MonoHooks/Runtime/Pairs/CollisionGameObjectPair.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using System;
 using UnityEngine;
 using UnityAtoms.MonoHooks;
@@ -20,3 +21,4 @@ namespace UnityAtoms.MonoHooks
         public void Deconstruct(out CollisionGameObject item1, out CollisionGameObject item2) { item1 = Item1; item2 = Item2; }
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/References/Collider2DGameObjectReference.cs
+++ b/Packages/MonoHooks/Runtime/References/Collider2DGameObjectReference.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using System;
 using UnityAtoms.BaseAtoms;
 using UnityAtoms.MonoHooks;
@@ -23,3 +24,4 @@ namespace UnityAtoms.MonoHooks
         public bool Equals(Collider2DGameObjectReference other) { return base.Equals(other); }
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/References/ColliderGameObjectReference.cs
+++ b/Packages/MonoHooks/Runtime/References/ColliderGameObjectReference.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using System;
 using UnityAtoms.BaseAtoms;
 using UnityAtoms.MonoHooks;
@@ -23,3 +24,4 @@ namespace UnityAtoms.MonoHooks
         public bool Equals(ColliderGameObjectReference other) { return base.Equals(other); }
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/References/Collision2DGameObjectReference.cs
+++ b/Packages/MonoHooks/Runtime/References/Collision2DGameObjectReference.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using System;
 using UnityAtoms.BaseAtoms;
 using UnityAtoms.MonoHooks;
@@ -23,3 +24,4 @@ namespace UnityAtoms.MonoHooks
         public bool Equals(Collision2DGameObjectReference other) { return base.Equals(other); }
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/References/CollisionGameObjectReference.cs
+++ b/Packages/MonoHooks/Runtime/References/CollisionGameObjectReference.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using System;
 using UnityAtoms.BaseAtoms;
 using UnityAtoms.MonoHooks;
@@ -23,3 +24,4 @@ namespace UnityAtoms.MonoHooks
         public bool Equals(CollisionGameObjectReference other) { return base.Equals(other); }
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/SyncVariableInstancerToCollection/SyncCollider2DGameObjectVariableInstancerToCollection.cs
+++ b/Packages/MonoHooks/Runtime/SyncVariableInstancerToCollection/SyncCollider2DGameObjectVariableInstancerToCollection.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 using UnityAtoms.BaseAtoms;
 using UnityAtoms.MonoHooks;
@@ -11,3 +12,4 @@ namespace UnityAtoms.MonoHooks
     [EditorIcon("atom-icon-delicate")]
     public class SyncCollider2DGameObjectVariableInstancerToCollection : SyncVariableInstancerToCollection<Collider2DGameObject, Collider2DGameObjectVariable, Collider2DGameObjectVariableInstancer> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/SyncVariableInstancerToCollection/SyncColliderGameObjectVariableInstancerToCollection.cs
+++ b/Packages/MonoHooks/Runtime/SyncVariableInstancerToCollection/SyncColliderGameObjectVariableInstancerToCollection.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 using UnityAtoms.BaseAtoms;
 using UnityAtoms.MonoHooks;
@@ -11,3 +12,4 @@ namespace UnityAtoms.MonoHooks
     [EditorIcon("atom-icon-delicate")]
     public class SyncColliderGameObjectVariableInstancerToCollection : SyncVariableInstancerToCollection<ColliderGameObject, ColliderGameObjectVariable, ColliderGameObjectVariableInstancer> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/SyncVariableInstancerToCollection/SyncCollision2DGameObjectVariableInstancerToCollection.cs
+++ b/Packages/MonoHooks/Runtime/SyncVariableInstancerToCollection/SyncCollision2DGameObjectVariableInstancerToCollection.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 using UnityAtoms.BaseAtoms;
 using UnityAtoms.MonoHooks;
@@ -11,3 +12,4 @@ namespace UnityAtoms.MonoHooks
     [EditorIcon("atom-icon-delicate")]
     public class SyncCollision2DGameObjectVariableInstancerToCollection : SyncVariableInstancerToCollection<Collision2DGameObject, Collision2DGameObjectVariable, Collision2DGameObjectVariableInstancer> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/SyncVariableInstancerToCollection/SyncCollisionGameObjectVariableInstancerToCollection.cs
+++ b/Packages/MonoHooks/Runtime/SyncVariableInstancerToCollection/SyncCollisionGameObjectVariableInstancerToCollection.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 using UnityAtoms.BaseAtoms;
 using UnityAtoms.MonoHooks;
@@ -11,3 +12,4 @@ namespace UnityAtoms.MonoHooks
     [EditorIcon("atom-icon-delicate")]
     public class SyncCollisionGameObjectVariableInstancerToCollection : SyncVariableInstancerToCollection<CollisionGameObject, CollisionGameObjectVariable, CollisionGameObjectVariableInstancer> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Types/Collider2DGameObject.cs
+++ b/Packages/MonoHooks/Runtime/Types/Collider2DGameObject.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using System;
 using UnityEngine;
 
@@ -73,3 +74,4 @@ namespace UnityAtoms.MonoHooks
         }
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Types/ColliderGameObject.cs
+++ b/Packages/MonoHooks/Runtime/Types/ColliderGameObject.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using System;
 using UnityEngine;
 
@@ -73,3 +74,4 @@ namespace UnityAtoms.MonoHooks
         }
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Types/Collision2DGameObject.cs
+++ b/Packages/MonoHooks/Runtime/Types/Collision2DGameObject.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using System;
 using UnityEngine;
 
@@ -73,3 +74,4 @@ namespace UnityAtoms.MonoHooks
         }
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Types/CollisionGameObject.cs
+++ b/Packages/MonoHooks/Runtime/Types/CollisionGameObject.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using System;
 using UnityEngine;
 
@@ -73,3 +74,4 @@ namespace UnityAtoms.MonoHooks
         }
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/UnityAtoms.UnityAtomsMonoHooks.Runtime.asmdef
+++ b/Packages/MonoHooks/Runtime/UnityAtoms.UnityAtomsMonoHooks.Runtime.asmdef
@@ -11,6 +11,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.modules.physics",
+            "expression": "0.0.0",
+            "define": "PACKAGE_UNITY_PHYSICS"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Packages/MonoHooks/Runtime/UnityAtoms.UnityAtomsMonoHooks.Runtime.asmdef
+++ b/Packages/MonoHooks/Runtime/UnityAtoms.UnityAtomsMonoHooks.Runtime.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "UnityAtoms.UnityAtomsMonoHooks.Runtime",
+    "rootNamespace": "",
     "references": [
         "UnityAtoms.UnityAtomsCore.Runtime",
         "UnityAtoms.UnityAtomsBaseAtoms.Runtime"
@@ -16,6 +17,11 @@
             "name": "com.unity.modules.physics",
             "expression": "0.0.0",
             "define": "PACKAGE_UNITY_PHYSICS"
+        },
+        {
+            "name": "com.unity.modules.physics2d",
+            "expression": "0.0.0",
+            "define": "PACKAGE_UNITY_PHYSICS2D"
         }
     ],
     "noEngineReferences": false

--- a/Packages/MonoHooks/Runtime/UnityEvents/Collider2DGameObjectPairUnityEvent.cs
+++ b/Packages/MonoHooks/Runtime/UnityEvents/Collider2DGameObjectPairUnityEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using System;
 using UnityEngine.Events;
 using UnityAtoms.MonoHooks;
@@ -10,3 +11,4 @@ namespace UnityAtoms.MonoHooks
     [Serializable]
     public sealed class Collider2DGameObjectPairUnityEvent : UnityEvent<Collider2DGameObjectPair> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/UnityEvents/Collider2DGameObjectUnityEvent.cs
+++ b/Packages/MonoHooks/Runtime/UnityEvents/Collider2DGameObjectUnityEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using System;
 using UnityEngine.Events;
 using UnityAtoms.MonoHooks;
@@ -10,3 +11,4 @@ namespace UnityAtoms.MonoHooks
     [Serializable]
     public sealed class Collider2DGameObjectUnityEvent : UnityEvent<Collider2DGameObject> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/UnityEvents/ColliderGameObjectPairUnityEvent.cs
+++ b/Packages/MonoHooks/Runtime/UnityEvents/ColliderGameObjectPairUnityEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using System;
 using UnityEngine.Events;
 using UnityAtoms.MonoHooks;
@@ -10,3 +11,4 @@ namespace UnityAtoms.MonoHooks
     [Serializable]
     public sealed class ColliderGameObjectPairUnityEvent : UnityEvent<ColliderGameObjectPair> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/UnityEvents/ColliderGameObjectUnityEvent.cs
+++ b/Packages/MonoHooks/Runtime/UnityEvents/ColliderGameObjectUnityEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using System;
 using UnityEngine.Events;
 using UnityAtoms.MonoHooks;
@@ -10,3 +11,4 @@ namespace UnityAtoms.MonoHooks
     [Serializable]
     public sealed class ColliderGameObjectUnityEvent : UnityEvent<ColliderGameObject> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/UnityEvents/Collision2DGameObjectPairUnityEvent.cs
+++ b/Packages/MonoHooks/Runtime/UnityEvents/Collision2DGameObjectPairUnityEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using System;
 using UnityEngine.Events;
 using UnityAtoms.MonoHooks;
@@ -10,3 +11,4 @@ namespace UnityAtoms.MonoHooks
     [Serializable]
     public sealed class Collision2DGameObjectPairUnityEvent : UnityEvent<Collision2DGameObjectPair> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/UnityEvents/Collision2DGameObjectUnityEvent.cs
+++ b/Packages/MonoHooks/Runtime/UnityEvents/Collision2DGameObjectUnityEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using System;
 using UnityEngine.Events;
 using UnityAtoms.MonoHooks;
@@ -10,3 +11,4 @@ namespace UnityAtoms.MonoHooks
     [Serializable]
     public sealed class Collision2DGameObjectUnityEvent : UnityEvent<Collision2DGameObject> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/UnityEvents/CollisionGameObjectPairUnityEvent.cs
+++ b/Packages/MonoHooks/Runtime/UnityEvents/CollisionGameObjectPairUnityEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using System;
 using UnityEngine.Events;
 using UnityAtoms.MonoHooks;
@@ -10,3 +11,4 @@ namespace UnityAtoms.MonoHooks
     [Serializable]
     public sealed class CollisionGameObjectPairUnityEvent : UnityEvent<CollisionGameObjectPair> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/UnityEvents/CollisionGameObjectUnityEvent.cs
+++ b/Packages/MonoHooks/Runtime/UnityEvents/CollisionGameObjectUnityEvent.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using System;
 using UnityEngine.Events;
 using UnityAtoms.MonoHooks;
@@ -10,3 +11,4 @@ namespace UnityAtoms.MonoHooks
     [Serializable]
     public sealed class CollisionGameObjectUnityEvent : UnityEvent<CollisionGameObject> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/ValueLists/Collider2DGameObjectValueList.cs
+++ b/Packages/MonoHooks/Runtime/ValueLists/Collider2DGameObjectValueList.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -10,3 +11,4 @@ namespace UnityAtoms.MonoHooks
     [CreateAssetMenu(menuName = "Unity Atoms/Value Lists/Collider2DGameObject", fileName = "Collider2DGameObjectValueList")]
     public sealed class Collider2DGameObjectValueList : AtomValueList<Collider2DGameObject, Collider2DGameObjectEvent> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/ValueLists/ColliderGameObjectValueList.cs
+++ b/Packages/MonoHooks/Runtime/ValueLists/ColliderGameObjectValueList.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -10,3 +11,4 @@ namespace UnityAtoms.MonoHooks
     [CreateAssetMenu(menuName = "Unity Atoms/Value Lists/ColliderGameObject", fileName = "ColliderGameObjectValueList")]
     public sealed class ColliderGameObjectValueList : AtomValueList<ColliderGameObject, ColliderGameObjectEvent> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/ValueLists/Collision2DGameObjectValueList.cs
+++ b/Packages/MonoHooks/Runtime/ValueLists/Collision2DGameObjectValueList.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -10,3 +11,4 @@ namespace UnityAtoms.MonoHooks
     [CreateAssetMenu(menuName = "Unity Atoms/Value Lists/Collision2DGameObject", fileName = "Collision2DGameObjectValueList")]
     public sealed class Collision2DGameObjectValueList : AtomValueList<Collision2DGameObject, Collision2DGameObjectEvent> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/ValueLists/CollisionGameObjectValueList.cs
+++ b/Packages/MonoHooks/Runtime/ValueLists/CollisionGameObjectValueList.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -10,3 +11,4 @@ namespace UnityAtoms.MonoHooks
     [CreateAssetMenu(menuName = "Unity Atoms/Value Lists/CollisionGameObject", fileName = "CollisionGameObjectValueList")]
     public sealed class CollisionGameObjectValueList : AtomValueList<CollisionGameObject, CollisionGameObjectEvent> { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/VariableInstancers/Collider2DGameObjectVariableInstancer.cs
+++ b/Packages/MonoHooks/Runtime/VariableInstancers/Collider2DGameObjectVariableInstancer.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 using UnityAtoms.BaseAtoms;
 using UnityAtoms.MonoHooks;
@@ -18,3 +19,4 @@ namespace UnityAtoms.MonoHooks
         Collider2DGameObjectCollider2DGameObjectFunction>
     { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/VariableInstancers/ColliderGameObjectVariableInstancer.cs
+++ b/Packages/MonoHooks/Runtime/VariableInstancers/ColliderGameObjectVariableInstancer.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 using UnityAtoms.BaseAtoms;
 using UnityAtoms.MonoHooks;
@@ -18,3 +19,4 @@ namespace UnityAtoms.MonoHooks
         ColliderGameObjectColliderGameObjectFunction>
     { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/VariableInstancers/Collision2DGameObjectVariableInstancer.cs
+++ b/Packages/MonoHooks/Runtime/VariableInstancers/Collision2DGameObjectVariableInstancer.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 using UnityAtoms.BaseAtoms;
 using UnityAtoms.MonoHooks;
@@ -18,3 +19,4 @@ namespace UnityAtoms.MonoHooks
         Collision2DGameObjectCollision2DGameObjectFunction>
     { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/VariableInstancers/CollisionGameObjectVariableInstancer.cs
+++ b/Packages/MonoHooks/Runtime/VariableInstancers/CollisionGameObjectVariableInstancer.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 using UnityAtoms.BaseAtoms;
 using UnityAtoms.MonoHooks;
@@ -18,3 +19,4 @@ namespace UnityAtoms.MonoHooks
         CollisionGameObjectCollisionGameObjectFunction>
     { }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Variables/Collider2DGameObjectVariable.cs
+++ b/Packages/MonoHooks/Runtime/Variables/Collider2DGameObjectVariable.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -12,3 +13,4 @@ namespace UnityAtoms.MonoHooks
     {
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Variables/ColliderGameObjectVariable.cs
+++ b/Packages/MonoHooks/Runtime/Variables/ColliderGameObjectVariable.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -12,3 +13,4 @@ namespace UnityAtoms.MonoHooks
     {
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Variables/Collision2DGameObjectVariable.cs
+++ b/Packages/MonoHooks/Runtime/Variables/Collision2DGameObjectVariable.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS2D
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -12,3 +13,4 @@ namespace UnityAtoms.MonoHooks
     {
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/Variables/CollisionGameObjectVariable.cs
+++ b/Packages/MonoHooks/Runtime/Variables/CollisionGameObjectVariable.cs
@@ -1,3 +1,4 @@
+#if PACKAGE_UNITY_PHYSICS
 using UnityEngine;
 using UnityAtoms.MonoHooks;
 
@@ -12,3 +13,4 @@ namespace UnityAtoms.MonoHooks
     {
     }
 }
+#endif


### PR DESCRIPTION
Unity Atoms cant handle physics and physics2d module being disabled on a project. This is a simples (but tedious) enhancement to fix it.

If anyone is going to test it, just uninstall physics module from Package Manager > Build-in and RESTART Unity. This was the only way that I could make sure that the asmdef version define was correctly updated. ( the other way us to update the expression on the asmdef). Same thing for checking if after reinstalling the package everything is working.

The define name was though as PACKAGE_(PARENTNAME)_(PACKAGENAME), skipping the modules. 
I.E: com.unity.modules.physics2d > PACKAGE_UNITY_PHYSICS2D. If there is any better patter please let me know.