### PR TITLE
add `replayEventsBuffer` option to `Action`-based `Register` call

### DIFF
--- a/Packages/Core/Runtime/Events/AtomEvent.cs
+++ b/Packages/Core/Runtime/Events/AtomEvent.cs
@@ -117,9 +117,21 @@ namespace UnityAtoms
         /// <summary>
         /// Register handler to be called when the Event triggers.
         /// </summary>
+        /// <remarks>
+        /// Replays the event buffer to the handler.
+        /// </remarks>
         /// <param name="action">The handler.</param>
-        /// <param name="replayEventsBuffer">If this replays the events buffer to the new listener. Defaults to true.</param>
-        public void Register(Action<T> action, bool replayEventsBuffer = true)
+        public void Register(Action<T> action)
+        {
+            Register(action, replayEventsBuffer: true);
+        }
+
+        /// <summary>
+        /// Register handler to be called when the Event triggers.
+        /// </summary>
+        /// <param name="action">The handler.</param>
+        /// <param name="replayEventsBuffer">If this replays the events buffer to the handler.</param>
+        public void Register(Action<T> action, bool replayEventsBuffer)
         {
             _onEvent += action;
             if (replayEventsBuffer)

--- a/Packages/Core/Runtime/Events/AtomEvent.cs
+++ b/Packages/Core/Runtime/Events/AtomEvent.cs
@@ -118,10 +118,14 @@ namespace UnityAtoms
         /// Register handler to be called when the Event triggers.
         /// </summary>
         /// <param name="action">The handler.</param>
-        public void Register(Action<T> action)
+        /// <param name="replayEventsBuffer">If this replays the events buffer to the new listener. Defaults to true.</param>
+        public void Register(Action<T> action, bool replayEventsBuffer = true)
         {
             _onEvent += action;
-            ReplayBufferToSubscriber(action);
+            if (replayEventsBuffer)
+            {
+                ReplayBufferToSubscriber(action);
+            }
         }
 
         /// <summary>
@@ -146,6 +150,7 @@ namespace UnityAtoms
         /// Register a Listener that in turn trigger all its associated handlers when the Event triggers.
         /// </summary>
         /// <param name="listener">The Listener to register.</param>
+        /// <param name="replayEventsBuffer">If this replays the events buffer to the new listener. Defaults to true.</param>
         public void RegisterListener(IAtomListener<T> listener, bool replayEventsBuffer = true)
         {
             _onEvent += listener.OnEventRaised;


### PR DESCRIPTION
presently, only the `AtomListener`-based overload of `Register` accepts a flag to skip the replay buffer. this adds the flag to the `Action`-based overload. it needed to be implemented as an overload, rather than an optional arg, because the current `Action`-overload is used as a method reference internally.