### PR TITLE
Add RemoveItem for AtomValueList for usage in UnityEvents

### DIFF
--- a/Packages/Core/Runtime/ValueLists/AtomValueList.cs
+++ b/Packages/Core/Runtime/ValueLists/AtomValueList.cs
@@ -129,6 +129,13 @@ namespace UnityAtoms
         }
 
         /// <summary>
+        /// Removes an item from the list. 
+        /// This is a wrapper for `bool Remove(T item)`, useful for usage in UnityEvents.
+        /// </summary>
+        /// <param name="item">The item to remove.</param>
+        public void RemoveItem(T item) => Remove(item);
+
+        /// <summary>
         /// Does the list contain the item provided?
         /// </summary>
         /// <param name="item">The item to check if it is contained in the list.</param>


### PR DESCRIPTION
As a developer, I want to reference an `AtomValueList` asset in a UnityEvent and modify it. `AtomValueList` already exposes a `Remove` but since it returns a `bool`, Unity will not display it as a function. This wraps the Remove function with a `void` so it can be called as a serialized function.

### Before:
![image](https://github.com/user-attachments/assets/f524ad82-69f8-4b64-a054-7770f13fa770)
### After:
![image](https://github.com/user-attachments/assets/e6ccf045-11f1-4872-87fd-b7fb5be09c1d)