### PR TITLE
feat: added ITryGetEvent and ITryGetOrCreateEvent interfaces 

### DIFF
--- a/Packages/Core/Runtime/EventInstancers/AtomEventInstancer.cs
+++ b/Packages/Core/Runtime/EventInstancers/AtomEventInstancer.cs
@@ -7,13 +7,14 @@ namespace UnityAtoms
 
     /// <summary>
     /// An Event Instancer is a MonoBehaviour that takes an Event as a base and creates an in memory copy of it on OnEnable.
-    /// This is handy when you want to use Events for prefabs that are instantiated at runtime. 
+    /// This is handy when you want to use Events for prefabs that are instantiated at runtime.
     /// </summary>
     /// <typeparam name="T">The value type.</typeparam>
     /// <typeparam name="E">Event of type T.</typeparam>
     [EditorIcon("atom-icon-sign-blue")]
     [DefaultExecutionOrder(Runtime.ExecutionOrder.VARIABLE_INSTANCER)]
-    public abstract class AtomEventInstancer<T, E> : MonoBehaviour, IGetEvent, ISetEvent, IAtomInstancer
+    public abstract class AtomEventInstancer<T, E>
+        : MonoBehaviour, IGetEvent, ISetEvent, IAtomInstancer, ITryGetOrCreateEvent
         where E : AtomEvent<T>
     {
         public T InspectorRaiseValue { get => _inspectorRaiseValue; }
@@ -65,8 +66,25 @@ namespace UnityAtoms
             throw new Exception($"Event type {typeof(EO)} not supported! Use {typeof(E)}.");
         }
 
+
+        public bool TryGetEvent<EO>(out EO atomEvent) where EO : AtomEventBase
+        {
+            atomEvent = typeof(EO) == typeof(E) ? Event as EO : null;
+            return atomEvent != null;
+        }
+
         /// <summary>
-        /// Set event by type. 
+        /// Safely (no exception) Get event by type.
+        /// Contrary to the name, a new event is never created as it makes no sense (OnEnable has that handled already).
+        /// This interface implementation is mostly for compatibility.
+        /// </summary>
+        public bool TryGetOrCreateEvent<EO>(out EO atomEvent) where EO : AtomEventBase
+        {
+            return TryGetEvent(out atomEvent);
+        }
+
+        /// <summary>
+        /// Set event by type.
         /// </summary>
         /// <param name="e">The new event value.</param>
         /// <typeparam name="E"></typeparam>
@@ -82,6 +100,7 @@ namespace UnityAtoms
         {
             Event.Raise();
         }
+
 
         /// <summary>
         /// Raises the instanced Event.

--- a/Packages/Core/Runtime/EventReferences/AtomBaseEventReference.cs
+++ b/Packages/Core/Runtime/EventReferences/AtomBaseEventReference.cs
@@ -78,7 +78,7 @@ namespace UnityAtoms
             else
                 Debug.LogError("Event is null");
         }
-        
+
         public void Raise(T value)
         {
             var eventRef = Event;
@@ -124,8 +124,15 @@ namespace UnityAtoms
             throw new Exception($"Event type {typeof(EO)} not supported! Use {typeof(E)}.");
         }
 
+
+        public bool TryGetEvent<EO>(out EO atomEvent) where EO : AtomEventBase
+        {
+            atomEvent = typeof(EO) == typeof(E) ? Event as EO : null;
+            return atomEvent != null;
+        }
+
         /// <summary>
-        /// Set event by type. 
+        /// Set event by type.
         /// </summary>
         /// <param name="e">The new event value.</param>
         /// <typeparam name="E"></typeparam>

--- a/Packages/Core/Runtime/EventReferences/AtomEventReference.cs
+++ b/Packages/Core/Runtime/EventReferences/AtomEventReference.cs
@@ -11,10 +11,11 @@ namespace UnityAtoms
     /// <typeparam name="E">Event of type `T`.</typeparam>
     /// <typeparam name="VI">Variable Instancer of type `T`.</typeparam>
     /// <typeparam name="EI">Event Instancer of type `T`.</typeparam>
-    public abstract class AtomEventReference<T, V, E, VI, EI> : AtomBaseEventReference<T, E, EI>, IGetEvent, ISetEvent
-        where V : IGetOrCreateEvent, ISetEvent
+    public abstract class AtomEventReference<T, V, E, VI, EI>
+        : AtomBaseEventReference<T, E, EI>, IGetEvent, ISetEvent, ITryGetOrCreateEvent, ITryGetEvent
+        where V : IGetOrCreateEvent, ITryGetEvent, ISetEvent
         where E : AtomEvent<T>
-        where VI : IGetOrCreateEvent, ISetEvent
+        where VI : IGetOrCreateEvent, ITryGetEvent, ISetEvent
         where EI : AtomEventInstancer<T, E>
     {
         /// <summary>
@@ -80,6 +81,52 @@ namespace UnityAtoms
         public static implicit operator E(AtomEventReference<T, V, E, VI, EI> reference)
         {
             return reference.Event;
+        }
+
+        public bool TryGetOrCreateEvent<E1>(out E1 atomEvent) where E1 : AtomEventBase
+        {
+            ITryGetOrCreateEvent bakingField = null;
+            switch (_usage)
+            {
+                case (AtomEventReferenceUsage.VARIABLE): bakingField = _variable; break;
+                case (AtomEventReferenceUsage.VARIABLE_INSTANCER): bakingField = _variableInstancer; break;
+                case (AtomEventReferenceUsage.EVENT_INSTANCER): bakingField = _eventInstancer; break;
+                case (AtomEventReferenceUsage.EVENT): bakingField = _event; break;
+                default: bakingField = null; break;
+            }
+            if (bakingField != null)
+            {
+                var result = bakingField.TryGetOrCreateEvent<E1>(out atomEvent);
+                return result;
+            }
+            else
+            {
+                atomEvent = null;
+                return false;
+            }
+        }
+
+        public bool TryGetEvent<E1>(out E1 atomEvent) where E1 : AtomEventBase
+        {
+            ITryGetEvent bakingField = null;
+            switch (_usage)
+            {
+                case (AtomEventReferenceUsage.VARIABLE): bakingField = _variable; break;
+                case (AtomEventReferenceUsage.VARIABLE_INSTANCER): bakingField = _variableInstancer; break;
+                case (AtomEventReferenceUsage.EVENT_INSTANCER): bakingField = _eventInstancer; break;
+                case (AtomEventReferenceUsage.EVENT): bakingField = _event; break;
+                default: bakingField = null; break;
+            }
+            if (bakingField != null)
+            {
+                var result = bakingField.TryGetEvent<E1>(out atomEvent);
+                return result;
+            }
+            else
+            {
+                atomEvent = null;
+                return false;
+            }
         }
     }
 }

--- a/Packages/Core/Runtime/Events/AtomEventBase.cs
+++ b/Packages/Core/Runtime/Events/AtomEventBase.cs
@@ -8,7 +8,7 @@ namespace UnityAtoms
     /// None generic base class for Events. Inherits from `BaseAtom` and `ISerializationCallbackReceiver`.
     /// </summary>
     [EditorIcon("atom-icon-cherry")]
-    public abstract class AtomEventBase : BaseAtom, ISerializationCallbackReceiver
+    public abstract class AtomEventBase : BaseAtom, ISerializationCallbackReceiver, ITryGetOrCreateEvent, ITryGetEvent
     {
         /// <summary>
         /// Event without value.
@@ -82,5 +82,31 @@ namespace UnityAtoms
             }
         }
 
+
+        /// <summary>
+        /// Contrary to the name, a new event is never created as it makes no sense (this is already an event class).
+        /// It is used for compatibility with the `ITryGetOrCreateEvent` interface.
+        /// </summary>
+        public bool TryGetOrCreateEvent<E>(out E atomEvent) where E : AtomEventBase
+        {
+            if (typeof(E).IsAssignableFrom(this.GetType()))
+            {
+                atomEvent = (E)this;
+                return true;
+            }
+            atomEvent = null;
+            return false;
+        }
+
+        public bool TryGetEvent<E>(out E atomEvent) where E : AtomEventBase
+        {
+            if (typeof(E).IsAssignableFrom(this.GetType()))
+            {
+                atomEvent = (E)this;
+                return true;
+            }
+            atomEvent = null;
+            return false;
+        }
     }
 }

--- a/Packages/Core/Runtime/Interfaces/IGetEvent.cs
+++ b/Packages/Core/Runtime/Interfaces/IGetEvent.cs
@@ -3,7 +3,7 @@ namespace UnityAtoms
     /// <summary>
     /// Interface for getting an event.
     /// </summary>
-    public interface IGetEvent
+    public interface IGetEvent : ITryGetEvent
     {
         E GetEvent<E>() where E : AtomEventBase;
     }

--- a/Packages/Core/Runtime/Interfaces/IGetOrCreateEvent.cs
+++ b/Packages/Core/Runtime/Interfaces/IGetOrCreateEvent.cs
@@ -3,7 +3,7 @@ namespace UnityAtoms
     /// <summary>
     /// Interface for getting or creating an event.
     /// </summary>
-    public interface IGetOrCreateEvent
+    public interface IGetOrCreateEvent : ITryGetOrCreateEvent
     {
         E GetOrCreateEvent<E>() where E : AtomEventBase;
     }

--- a/Packages/Core/Runtime/Interfaces/ITryGetEvent.cs
+++ b/Packages/Core/Runtime/Interfaces/ITryGetEvent.cs
@@ -1,0 +1,11 @@
+﻿namespace UnityAtoms
+{
+    /// <summary>
+    /// Interface for trying to get an event.
+    /// Used in references, where the underlying object may not always support events.
+    /// </summary>
+    public interface ITryGetEvent
+    {
+        bool TryGetEvent<E>(out E atomEvent) where E : AtomEventBase;
+    }
+}

--- a/Packages/Core/Runtime/Interfaces/ITryGetEvent.cs.meta
+++ b/Packages/Core/Runtime/Interfaces/ITryGetEvent.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 82a7f35b6cd74f56873ec84065129b3e
+timeCreated: 1750100387

--- a/Packages/Core/Runtime/Interfaces/ITryGetOrCreateEvent.cs
+++ b/Packages/Core/Runtime/Interfaces/ITryGetOrCreateEvent.cs
@@ -1,0 +1,11 @@
+﻿namespace UnityAtoms
+{
+    /// <summary>
+    /// Interface for trying to get or create an event.
+    /// Used in references, where the underlying object may not always support events.
+    /// </summary>
+    public interface ITryGetOrCreateEvent
+    {
+        bool TryGetOrCreateEvent<E>(out E atomEvent) where E : AtomEventBase;
+    }
+}

--- a/Packages/Core/Runtime/Interfaces/ITryGetOrCreateEvent.cs.meta
+++ b/Packages/Core/Runtime/Interfaces/ITryGetOrCreateEvent.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d2de2a56e08d484099f7047e64152538
+timeCreated: 1750100309

--- a/Packages/Core/Runtime/VariableInstancers/AtomVariableInstancer.cs
+++ b/Packages/Core/Runtime/VariableInstancers/AtomVariableInstancer.cs
@@ -47,13 +47,13 @@ namespace UnityAtoms
                 _inMemoryCopy.ChangedWithHistory = _inMemoryCopy.GetOrCreateEvent<E2>();
             }
 
-            // Manually trigger initial events since base class has already instantiated Variable 
+            // Manually trigger initial events since base class has already instantiated Variable
             // and the Variable's OnEnable hook has therefore already been executed.
             _inMemoryCopy.TriggerInitialEvents();
         }
 
         /// <summary>
-        /// Get event by type. 
+        /// Get event by type.
         /// </summary>
         /// <typeparam name="E"></typeparam>
         /// <returns>The event.</returns>
@@ -62,8 +62,18 @@ namespace UnityAtoms
             return _inMemoryCopy.GetEvent<E>();
         }
 
+        public bool TryGetEvent<E>(out E atomEvent) where E : AtomEventBase
+        {
+            return _inMemoryCopy.TryGetEvent<E>(out atomEvent);
+        }
+
+        public bool TryGetOrCreateEvent<E>(out E atomEvent) where E : AtomEventBase
+        {
+            return _inMemoryCopy.TryGetOrCreateEvent<E>(out atomEvent);
+        }
+
         /// <summary>
-        /// Set event by type. 
+        /// Set event by type.
         /// </summary>
         /// <param name="e">The new event value.</param>
         /// <typeparam name="E"></typeparam>
@@ -81,5 +91,6 @@ namespace UnityAtoms
         {
             return _inMemoryCopy.GetOrCreateEvent<E>();
         }
+
     }
 }

--- a/Packages/Core/Runtime/Variables/AtomVariable.cs
+++ b/Packages/Core/Runtime/Variables/AtomVariable.cs
@@ -159,7 +159,7 @@ namespace UnityAtoms
             // NOTE: This will not be called when deleting the Atom from the editor.
             // Therefore, there might still be null instances, but even though not ideal,
             // it should not cause any problems.
-            // More info: https://issuetracker.unity3d.com/issues/ondisable-and-ondestroy-methods-are-not-called-when-a-scriptableobject-is-deleted-manually-in-project-window 
+            // More info: https://issuetracker.unity3d.com/issues/ondisable-and-ondestroy-methods-are-not-called-when-a-scriptableobject-is-deleted-manually-in-project-window
 #if UNITY_EDITOR
             _instances.Remove(this);
 #endif
@@ -341,15 +341,7 @@ namespace UnityAtoms
         /// </returns>
         public E GetEvent<E>() where E : AtomEventBase
         {
-            if (typeof(E) == typeof(E1))
-            {
-                return Changed as E;
-            }
-            if (typeof(E) == typeof(E2))
-            {
-                return ChangedWithHistory as E;
-            }
-
+            if(TryGetEvent(out E result)) return result;
             throw new NotSupportedException($"Event type {typeof(E)} not supported! Use {typeof(E1)} or {typeof(E2)}.");
         }
 
@@ -384,6 +376,29 @@ namespace UnityAtoms
         /// </returns>
         public E GetOrCreateEvent<E>() where E : AtomEventBase
         {
+            if (TryGetOrCreateEvent(out E result)) return result;
+
+            throw new NotSupportedException($"Event type {typeof(E)} not supported! Use {typeof(E1)} or {typeof(E2)}.");
+        }
+
+        public bool TryGetEvent<E>(out E atomEvent) where E : AtomEventBase
+        {
+            if (typeof(E) == typeof(E1))
+            {
+                atomEvent = Changed as E;
+                return true;
+            }
+            if (typeof(E) == typeof(E2))
+            {
+                atomEvent = ChangedWithHistory as E;
+                return true;
+            }
+            atomEvent = null;
+            return false;
+        }
+
+        public bool TryGetOrCreateEvent<E>(out E atomEvent) where E : AtomEventBase
+        {
             if (typeof(E) == typeof(E1))
             {
                 if (_changed == null)
@@ -392,7 +407,8 @@ namespace UnityAtoms
                     _changed.name = $"{(String.IsNullOrWhiteSpace(name) ? "" : $"{name}_")}ChangedEvent_Runtime_{typeof(E1)}";
                 }
 
-                return _changed as E;
+                atomEvent = _changed as E;
+                return true;
             }
             if (typeof(E) == typeof(E2))
             {
@@ -402,10 +418,11 @@ namespace UnityAtoms
                     _changedWithHistory.name = $"{(String.IsNullOrWhiteSpace(name) ? "" : $"{name}_")}ChangedWithHistoryEvent_Runtime_{typeof(E2)}";
                 }
 
-                return _changedWithHistory as E;
+                atomEvent = _changedWithHistory as E;
+                return true;
             }
-
-            throw new NotSupportedException($"Event type {typeof(E)} not supported! Use {typeof(E1)} or {typeof(E2)}.");
+            atomEvent = null;
+            return false;
         }
     }
 }


### PR DESCRIPTION
feat: added ITryGetEvent and ITryGetOrCreateEvent interfaces and implemented them.

    this unifies all kinds of usages of AtomReferences into the same, non-throwing pattern.

closes #392