### PR TITLE
fix: if not in playmode treat Variable.Value as InitialValue

### DIFF
--- a/Packages/Core/Editor/Drawers/VariableDrawer.cs
+++ b/Packages/Core/Editor/Drawers/VariableDrawer.cs
@@ -18,7 +18,8 @@ namespace UnityAtoms.Editor
             position = EditorGUI.PrefixLabel(position, label);
 
             var inner = new SerializedObject(property.objectReferenceValue);
-            var valueProp = inner.FindProperty("_value");
+            var valueProp = inner.FindProperty(Application.isPlaying ? "_value" : "_initialValue")
+                ?? inner.FindProperty("_value"); // for AtomConstants, there is no _initialValue
             Rect previewRect = new Rect(position);
             previewRect.width = GetPreviewSpace(valueProp?.type);
             position.xMin = previewRect.xMax;

--- a/Packages/Core/Runtime/Variables/AtomVariable.cs
+++ b/Packages/Core/Runtime/Variables/AtomVariable.cs
@@ -27,7 +27,26 @@ namespace UnityAtoms
         /// The Variable value as a property.
         /// </summary>
         /// <returns>Get or set the Variable's value.</returns>
-        public override T Value { get => _value; set => SetValue(value); }
+        public override T Value
+        {
+            get
+            {
+                #if UNITY_EDITOR
+                try
+                {
+                    if (!Application.isPlaying) return InitialValue;
+                }
+                catch (UnityException)
+                {
+                    // "get_isPlaying is not allowed to be called during serialization"
+                    // -> while compiling we can savely return InitialValue as OnEnable is to about to set Value = InitialValue
+                    return InitialValue;
+                }
+                #endif
+                return _value;
+            }
+            set => SetValue(value);
+        }
 
         /// <summary>
         /// The initial value as a property.


### PR DESCRIPTION
second part of #469 